### PR TITLE
fixes Spikes mapping issue: Trim space on JiraItem type

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -371,7 +371,7 @@ namespace JiraExport
         private readonly JiraProvider _provider;
 
         public string Key { get { return RemoteIssue.ExValue<string>("$.key"); } }
-        public string Type { get { return RemoteIssue.ExValue<string>("$.fields.issuetype.name"); } }
+        public string Type { get { return RemoteIssue.ExValue<string>("$.fields.issuetype.name")?.Trim(); } }
 
         public string EpicParent { get { return RemoteIssue.ExValue<string>($"$.fields.{_provider.Settings.EpicLinkField}"); } }
         public string Parent { get { return RemoteIssue.ExValue<string>("$.fields.parent.key"); } }


### PR DESCRIPTION
Our Jira projects are configured to use Spikes. However, the rest api for jira issues seems to return the issue Type with space after the work "Spikes".

This fixes the issue so that the type is not null after select statement in **JiraMapper.cs** Line **127**

```csharp
var type = (from t in _config.TypeMap.Types where t.Source == issue.Type select t.Target)
    .FirstOrDefault();

if (type != null)
...
```

**Before**
![console-output](https://user-images.githubusercontent.com/217568/54023666-70318b00-418d-11e9-872f-a55fa6eb0bff.PNG)
![spikeissuetypewithoutextraspace](https://user-images.githubusercontent.com/217568/54023779-bedf2500-418d-11e9-801e-debf75511cd6.PNG)

**After**
![consoleoutputafter](https://user-images.githubusercontent.com/217568/54023702-7e7fa700-418d-11e9-9bb6-969af3e94e80.PNG)
![spikeissuetypewithoutextraspace](https://user-images.githubusercontent.com/217568/54023705-80496a80-418d-11e9-8bbe-76244ee3d66a.PNG)
