### PR TITLE
Corrected JSON Path for changelog history

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraProvider.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraProvider.cs
@@ -220,7 +220,7 @@ namespace JiraExport
         public IEnumerable<JObject> DownloadChangelog(string issueKey)
         {
             var response = (JObject)Jira.RestClient.ExecuteRequestAsync(RestSharp.Method.GET, $"rest/api/2/issue/{issueKey}?expand=changelog&fields=created").Result;
-            return response.SelectTokens("$.histories[*]").Cast<JObject>();
+            return response.SelectTokens("$.changelog.histories[*]").Cast<JObject>();
         }
 
         public JObject DownloadIssue(string key)


### PR DESCRIPTION
Corrected JSON Path for changelog history because it was incorrect and therefore not returning any history.