### PR TITLE
fix: correctly map arrays based off value key

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -346,7 +346,7 @@ namespace JiraExport
                 else if (type == JTokenType.Array && prop.Value.Any())
                 {
                     value = string.Join(";", prop.Value.Select(st => st.ExValue<string>("$.name")).ToList());
-                    if ((string)value == ";")
+                    if ((string)value == ";" || (string)value == "")
                         value = string.Join(";", prop.Value.Select(st => st.ExValue<string>("$.value")).ToList());
                 }
 


### PR DESCRIPTION
With some fields I was seeing this block get skipped over because value was `""` instead of `";"` I honestly dont know if it would ever be `";"`, but I left it to stay on the safe side. If you guys think that can be removed let me know and I can update this pr.

Hitting a few snags when using this but it is still saving me a ton of time, great work!