### PR TITLE
Add option to continue on a critical error

### DIFF
--- a/docs/wi-import.md
+++ b/docs/wi-import.md
@@ -11,6 +11,7 @@ Work item migration tool that assists with moving Jira items to Azure DevOps or 
 |--url \<accounturl>|True|Url for the account|
 |--config \<configurationfilename>|True|Import the work items based on the configuration file|
 |--force|False|Force execution from start (instead of continuing from previous run)|
+|--continue \<boolean>|False|Continue execution upon a critical error|
 
 **Note:** if the project defined in configuration does not exist, you´ll get a question if you want to create it. 
 

--- a/src/WorkItemMigrator/Migration.Common.Log/Logger.cs
+++ b/src/WorkItemMigrator/Migration.Common.Log/Logger.cs
@@ -41,7 +41,7 @@ namespace Migration.Common.Log
             }
             _logFilePath = Path.Combine(dirPath, $"{app}-log-{DateTime.Now.ToString("yyMMdd-HHmmss")}.txt");
             _logLevel = GetLogLevelFromString(level);
-            _continueOnCritical = string.IsNullOrEmpty(continueOnCritical) ? default(bool?) : bool.Parse(continueOnCritical);
+            _continueOnCritical = ParseContinueOnCritical(continueOnCritical);
         }
         
         public static void StartSession(string app, string message, Dictionary<string, string> context, Dictionary<string, string> properties)
@@ -231,6 +231,23 @@ namespace Migration.Common.Log
                 case LogLevel.Critical: return "C";
                 default: return "I";
             }
+        }
+
+        private static bool? ParseContinueOnCritical(string continueOnCritical)
+        {
+            if (string.IsNullOrEmpty(continueOnCritical))
+            {
+                return null;
+            }
+
+            var success = bool.TryParse(continueOnCritical, out var result);
+
+            if (!success)
+            {
+                return null;
+            }
+
+            return result;
         }
 
         public static int Warnings => _warnings.Count;

--- a/src/WorkItemMigrator/Migration.Common/MigrationContext.cs
+++ b/src/WorkItemMigrator/Migration.Common/MigrationContext.cs
@@ -28,11 +28,11 @@ namespace Migration.Common
             ForceFresh = forceFresh;
         }
 
-        public static MigrationContext Init(string app, string workspacePath, string logLevel, bool forceFresh)
+        public static MigrationContext Init(string app, string workspacePath, string logLevel, bool forceFresh, string continueOnCritical)
         {
             Instance = new MigrationContext(app, workspacePath, logLevel, forceFresh);
 
-            Logger.Init(app, workspacePath, logLevel);
+            Logger.Init(app, workspacePath, logLevel, continueOnCritical);
 
             Instance.Journal = Journal.Init(Instance);
             Instance.Provider = new WiItemProvider(Instance.MigrationWorkspace);

--- a/src/WorkItemMigrator/WorkItemImport/ImportCommandLine.cs
+++ b/src/WorkItemMigrator/WorkItemImport/ImportCommandLine.cs
@@ -43,6 +43,8 @@ namespace WorkItemImport
             CommandOption urlOption = commandLineApplication.Option("--url <accounturl>", "Url for the account", CommandOptionType.SingleValue);
             CommandOption configOption = commandLineApplication.Option("--config <configurationfilename>", "Import the work items based on the configuration file", CommandOptionType.SingleValue);
             CommandOption forceOption = commandLineApplication.Option("--force", "Forces execution from start (instead of continuing from previous run)", CommandOptionType.NoValue);
+            CommandOption continueOnCriticalOption = commandLineApplication.Option("--continue", "Continue execution upon a critical error", CommandOptionType.SingleValue);
+
 
             commandLineApplication.OnExecute(() =>
             {
@@ -50,7 +52,7 @@ namespace WorkItemImport
 
                 if (configOption.HasValue())
                 {
-                    ExecuteMigration(tokenOption, urlOption, configOption, forceFresh);
+                    ExecuteMigration(tokenOption, urlOption, configOption, forceFresh, continueOnCriticalOption);
                 }
                 else
                 {
@@ -61,7 +63,7 @@ namespace WorkItemImport
             });
         }
 
-        private void ExecuteMigration(CommandOption token, CommandOption url, CommandOption configFile, bool forceFresh)
+        private void ExecuteMigration(CommandOption token, CommandOption url, CommandOption configFile, bool forceFresh, CommandOption continueOnCritical)
         {
             ConfigJson config = null;
             var itemCount = 0;
@@ -76,7 +78,7 @@ namespace WorkItemImport
                 ConfigReaderJson configReaderJson = new ConfigReaderJson(configFileName);
                 config = configReaderJson.Deserialize();
 
-                var context = MigrationContext.Init("wi-import", config.Workspace, config.LogLevel, forceFresh);
+                var context = MigrationContext.Init("wi-import", config.Workspace, config.LogLevel, forceFresh, continueOnCritical.Value());
 
                 // connection settings for Azure DevOps/TFS:
                 // full base url incl https, name of the project where the items will be migrated (if it doesn't exist on destination it will be created), personal access token


### PR DESCRIPTION
Currently the migrator asks the user what to do on a critical error. This can be inconvenient for the user as you have to keep an eye on the import process to ensure it continues importing.

This PR adds a command line parameter to already give an answer what to do when a critical error occurs.

There are 4 options for the parameter:
- not supplied: use current behaviour and ask what to do
- supplied with "true" value: answer the question as though you pressed 'y'
- supplied with "false" value: answer the question as though you pressed 'n'
- supplied with non boolean value: use current behaviour and ask what to do