### PR TITLE
Updated JiraMapper with target Types for field mapping - including lo…

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -70,8 +70,8 @@ Name-value pairs of work item types to map in the migration.
 |**source**|True|string|Name of Jira source field.|
 |**target**|True|string|Name of Azure DevOps/TFS target field (reference name).|
 |**source-type**|False|string|Name of Jira field to get custom field id from. Default = "id".|
-|**for**|False|string|Types of work items this field should be migrated to, i.e. Bug, Task, Product backlog item in a comma-delimiter list. Default = "All".|
-|**not-for**|False|string|Negation of above, i.e this field is for a Bug only and nothing else.|
+|**for**|False|string|Types of work items this field should be migrated to, i.e. Bug, Task, Product backlog item in a comma-delimiter list. Default = "All".  When adding for ensure that a TypeMap.target is specified, specifying a TypeMap.source will cause fields to not be merged.|
+|**not-for**|False|string|Negation of above, i.e this field is for a Bug only and nothing else.  When adding for ensure that a TypeMap.target is specified, specifying a TypeMap.source will cause fields to not be merged.|
 |**type**|False|string|Data type, i.e string, int, double. Default = string|
 |**mapper**|False|string|Mapper function used for value translation.|
 |**mapping**|False|json|List of **values** to map to and from in the migration.|

--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -16,12 +16,14 @@ namespace JiraExport
     {
         private readonly JiraProvider _jiraProvider;
         private readonly Dictionary<string, FieldMapping<JiraRevision>> _fieldMappingsPerType;
+        private readonly HashSet<string> _targetTypes;
         private readonly ConfigJson _config;
 
         public JiraMapper(JiraProvider jiraProvider, ConfigJson config) : base(jiraProvider?.Settings?.UserMappingFile)
         {
             _jiraProvider = jiraProvider;
             _config = config;
+            _targetTypes = InitializeTypeMappings();
             _fieldMappingsPerType = InitializeFieldMappings();
         }
 
@@ -81,11 +83,11 @@ namespace JiraExport
             List<string> list;
             if (notFor != null && notFor.Any())
             {
-                list = WorkItemType.GetWorkItemTypes(notFor);
+                list = _targetTypes.Where(t => !notFor.Contains(t)).ToList();
             }
             else
             {
-                list = WorkItemType.GetWorkItemTypes();
+                list = _targetTypes.ToList();
             }
             return list;
         }
@@ -261,18 +263,25 @@ namespace JiraExport
             return fields;
         }
 
+        private HashSet<string> InitializeTypeMappings()
+        {
+            HashSet<string> types = new HashSet<string>();
+            _config.TypeMap.Types.ForEach(t => types.Add(t.Target));
+            return types;
+        }
+
         private Dictionary<string, FieldMapping<JiraRevision>> InitializeFieldMappings()
         {
-            var commonFields = new FieldMapping<JiraRevision>();
-            var bugFields = new FieldMapping<JiraRevision>();
-            var taskFields = new FieldMapping<JiraRevision>();
-            var pbiFields = new FieldMapping<JiraRevision>();
-            var epicFields = new FieldMapping<JiraRevision>();
-            var featureFields = new FieldMapping<JiraRevision>();
-            var requirementFields = new FieldMapping<JiraRevision>();
-            var userStoryFields = new FieldMapping<JiraRevision>();
-
             Logger.Log(LogLevel.Info, "Initializing Jira field mapping...");
+
+            var commonFields = new FieldMapping<JiraRevision>();
+            var typeFields = new Dictionary<string, FieldMapping<JiraRevision>>();
+
+            foreach(var targetType in _targetTypes)
+            {
+                if (!typeFields.ContainsKey(targetType))
+                    typeFields.Add(targetType, new FieldMapping<JiraRevision>());
+            }
 
             foreach (var item in _config.FieldMap.Fields)
             {
@@ -333,7 +342,7 @@ namespace JiraExport
                         }
                     }
 
-                    // Check if not-for has been set, if so get all work item types except that one, else for has been set and get those
+                    // Check if not-for has been set, if so get all work item types except that one, else for has been set and get those                 
                     var currentWorkItemTypes = !string.IsNullOrWhiteSpace(item.NotFor) ? GetWorkItemTypes(item.NotFor.Split(',')) : item.For.Split(',').ToList();
 
                     foreach (var wit in currentWorkItemTypes)
@@ -342,48 +351,29 @@ namespace JiraExport
                         {
                             commonFields.Add(item.Target, value);
                         }
-                        else if (wit == WorkItemType.Bug)
+                        else
                         {
-                            bugFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.Epic)
-                        {
-                            epicFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.Feature)
-                        {
-                            featureFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.ProductBacklogItem)
-                        {
-                            pbiFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.Requirement)
-                        {
-                            requirementFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.Task)
-                        {
-                            taskFields.Add(item.Target, value);
-                        }
-                        else if (wit == WorkItemType.UserStory)
-                        {
-                            userStoryFields.Add(item.Target, value);
+                            // If we haven't mapped the Type then we probably want to ignore the field
+                            if (typeFields.TryGetValue(wit, out FieldMapping<JiraRevision> fm)) 
+                            {
+                                fm.Add(item.Target, value);
+                            }
+                            else
+                            {
+                                Logger.Log(LogLevel.Warning, $"No target type '{wit}' is set, field {item.Source} cannot be mapped.");
+                            }
                         }
                     }
                 }
             }
 
-            var mappingPerWiType = new Dictionary<string, FieldMapping<JiraRevision>>
+            // Now go through the list of built up type fields (which we will eventually get to
+            // and then add them to the complete dictionary per type.
+            var mappingPerWiType = new Dictionary<string, FieldMapping<JiraRevision>>();
+            foreach (KeyValuePair<string, FieldMapping<JiraRevision>> item in typeFields)
             {
-                { WorkItemType.Bug, MergeMapping(commonFields, bugFields) },
-                { WorkItemType.ProductBacklogItem, MergeMapping(commonFields, pbiFields) },
-                { WorkItemType.Task, MergeMapping(commonFields, taskFields) },
-                { WorkItemType.Feature, MergeMapping(commonFields, featureFields) },
-                { WorkItemType.Epic, MergeMapping(commonFields, epicFields) },
-                { WorkItemType.Requirement, MergeMapping(commonFields, requirementFields) },
-                { WorkItemType.UserStory, MergeMapping(commonFields, userStoryFields) }
-            };
+                mappingPerWiType.Add(item.Key, MergeMapping(commonFields, item.Value));
+            }
 
             return mappingPerWiType;
         }


### PR DESCRIPTION
Issue #59 Resolved an issue where if a custom Type wasn't one of the 6 hard coded Types fields would not be merged.   Updated the JiraMapper to initialize with TypeMap.Targets only, since it was using those values to lookup the field mappings anyhow.