### PR TITLE
Avoiding the KeyNotFoundException in JiraItems.cs

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -36,6 +36,10 @@ namespace JiraExport
             List<JiraAttachment> attachments = ExtractAttachments(remoteIssue.SelectTokens("$.fields.attachment[*]").Cast<JObject>()) ?? new List<JiraAttachment>();
             List<JiraLink> links = ExtractLinks(issueKey, remoteIssue.SelectTokens("$.fields.issuelinks[*]").Cast<JObject>()) ?? new List<JiraLink>();
 
+            // save these field since these might be removed in the loop
+            var reporter = (string)fields["reporter"];
+            var createdOn = (DateTime)fields["created"];
+            
             var changelog = jiraProvider.DownloadChangelog(issueKey).ToList();
             changelog.Reverse();
 
@@ -95,10 +99,7 @@ namespace JiraExport
             var attActions = attachments.Select(a => new RevisionAction<JiraAttachment>() { ChangeType = RevisionChangeType.Added, Value = a }).ToList();
             var linkActions = links.Select(l => new RevisionAction<JiraLink>() { ChangeType = RevisionChangeType.Added, Value = l }).ToList();
             var fieldActions = fields;
-
-            var reporter = (string)fields["reporter"];
-            var createdOn = (DateTime)fields["created"];
-
+            
             var firstRevision = new JiraRevision(jiraItem) { Time = createdOn, Author = reporter, AttachmentActions = attActions, Fields = fieldActions, LinkActions = linkActions };
             revisions.Push(firstRevision);
             var listOfRevisions = revisions.ToList();

--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -37,7 +37,7 @@ namespace JiraExport
             List<JiraLink> links = ExtractLinks(issueKey, remoteIssue.SelectTokens("$.fields.issuelinks[*]").Cast<JObject>()) ?? new List<JiraLink>();
 
             // save these field since these might be removed in the loop
-            var reporter = (string)fields["reporter"];
+            var reporter = fields.TryGetValue("reporter", out object rep) ? (string) rep : null;
             var createdOn = (DateTime)fields["created"];
             
             var changelog = jiraProvider.DownloadChangelog(issueKey).ToList();


### PR DESCRIPTION
The fields [reporter] and [created] were accessed after the look. However, under certain circumstances these fields might be removed within the foreach-loop from the [fields] dictionary and the KeyNotFoundException is then thrown.

By placing these field before the foreach-loop we ensure that the values are always in the dictionary and so avoid the exception.