### PR TITLE
Feature/52 links not added to workitem

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -565,13 +565,39 @@ namespace WorkItemImport
 
             if (linkEnd != null)
             {
-                var relatedLink = new RelatedLink(linkEnd, link.TargetWiId);
-                relatedLink = ResolveCiclycalLinks(relatedLink, wi);
-                wi.Links.Add(relatedLink);
-                return true;
+                try
+                {
+                    var relatedLink = new RelatedLink(linkEnd, link.TargetWiId);
+                    relatedLink = ResolveCiclycalLinks(relatedLink, wi);
+                    if (!IsDuplicateWorkItemLink(wi.Links, relatedLink))
+                    {
+                        wi.Links.Add(relatedLink);
+                        return true;
+                    }
+                    return false;
+                }
+
+                catch (Exception ex)
+                {
+
+                    Logger.Log(LogLevel.Error, ex.Message);
+                    return false;
+                }
             }
             else
                 return false;
+
+        }
+
+        private bool IsDuplicateWorkItemLink(LinkCollection links, RelatedLink relatedLink)
+        {
+            if (links.Contains(relatedLink))
+            {
+                Logger.Log(LogLevel.Warning, $"Duplicate work item link: {relatedLink}");
+                return false;
+            }
+            return true;
+
 
         }
 

--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -610,7 +610,7 @@ namespace WorkItemImport
         {
             if (links.Contains(relatedLink))
             {
-                Logger.Log(LogLevel.Warning, $"Duplicate work item link: {relatedLink}");
+                Logger.Log(LogLevel.Warning, $"Duplicate work item link, related workitem id: {relatedLink.RelatedWorkItemId}");
                 return false;
             }
             return true;


### PR DESCRIPTION
When a duplicate link was being added to the Workitem, the exception was not caught. Adding try-catch when adding links to workitem, to catch exceptions. Checking if the link to be added is not a duplicated link in the existing links collection.