### PR TITLE
Links missing for migrated items

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -625,9 +625,9 @@ namespace WorkItemImport
             if (links.Contains(relatedLink))
             {
                 Logger.Log(LogLevel.Warning, $"Duplicate work item link, related workitem id: {relatedLink.RelatedWorkItemId}");
-                return false;
+                return true;
             }
-            return true;
+            return false;
 
 
         }


### PR DESCRIPTION
Links were not added on migration because of true and false conditions were returned in the incorrect order.