### PR TITLE
System.ArgumentException: An item with the same key has already been added

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -366,7 +366,7 @@ namespace JiraExport
                             }
                         }
 
-                        catch (Exception e)
+                        catch (Exception)
                         {
                             Logger.Log(LogLevel.Warning, $"Ignoring target mapping with key: '{item.Target}', because it is already configured.");
                             continue;

--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -346,21 +346,30 @@ namespace JiraExport
 
                     foreach (var wit in currentWorkItemTypes)
                     {
-                        if (wit == "All" || wit == "Common")
+                        try
                         {
-                            commonFields.Add(item.Target, value);
-                        }
-                        else
-                        {
-                            // If we haven't mapped the Type then we probably want to ignore the field
-                            if (typeFields.TryGetValue(wit, out FieldMapping<JiraRevision> fm))
+                            if (wit == "All" || wit == "Common")
                             {
-                                fm.Add(item.Target, value);
+                                commonFields.Add(item.Target, value);
                             }
                             else
                             {
-                                Logger.Log(LogLevel.Warning, $"No target type '{wit}' is set, field {item.Source} cannot be mapped.");
+                                // If we haven't mapped the Type then we probably want to ignore the field
+                                if (typeFields.TryGetValue(wit, out FieldMapping<JiraRevision> fm))
+                                {
+                                    fm.Add(item.Target, value);
+                                }
+                                else
+                                {
+                                    Logger.Log(LogLevel.Warning, $"No target type '{wit}' is set, field {item.Source} cannot be mapped.");
+                                }
                             }
+                        }
+
+                        catch (Exception e)
+                        {
+                            Logger.Log(LogLevel.Warning, $"Ignoring target mapping with key: '{item.Target}', because it is already configured.");
+                            continue;
                         }
                     }
                 }


### PR DESCRIPTION
Adding try-catch to when adding mapping values to a dictionary. If a duplicate is found catch exception, log it and continue.