### PR TITLE
Show warning when duplicate user mapping found

### DIFF
--- a/src/WorkItemMigrator/Migration.Common/UserMapper.cs
+++ b/src/WorkItemMigrator/Migration.Common/UserMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+
 using Migration.Common.Log;
 
 namespace Migration.Common
@@ -25,7 +26,10 @@ namespace Migration.Common
                         string jiraUser = userMappingParts[0].Trim();
                         string wiUser = userMappingParts[1].Trim();
 
-                        internalUserMapping.Add(jiraUser, wiUser);
+                        if (!internalUserMapping.ContainsKey(jiraUser))
+                            internalUserMapping.Add(jiraUser, wiUser);
+                        else
+                            Logger.Log(LogLevel.Warning, $"Duplicate mapping found {jiraUser}={wiUser} in user mapping configuration file");
                     }
                 }
             }


### PR DESCRIPTION
Added sanity check before adding a user with a key to the user mapping dictionary. If Key exists we will show a warning that a duplicate configuration was found.