### PR TITLE
Removed invalid characters from sprint names.

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -400,6 +400,7 @@ namespace WorkItemImport
 
                         if (!string.IsNullOrWhiteSpace(iterationPath))
                         {
+                            iterationPath = Regex.Replace(iterationPath, "[\\/$?*:\"&<>#%|+]", "");
                             EnsureClasification(iterationPath, WebModel.TreeStructureGroup.Iterations);
                             wi.IterationPath = $@"{Settings.Project}\{iterationPath}".Replace("/", @"\");
                         }


### PR DESCRIPTION
Our sprint names in Jira contains characters that are not allowed in Azure DevOps. Adding a line to replace those characters them during the import process Replace "[\\/$?*:\"&<>#%|+]" by "".