### PR TITLE
#200 - Multiple attachments in description were not migrated correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ Training
 Shop
 Blog
 About
+
+# Visual Code
+**/.ionide

--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -826,7 +826,7 @@ namespace WorkItemImport
 
                     if (tfsAtt != null)
                     {
-                        string imageSrcPattern = "src.*?=.*?\"([^\"]).*?\"";
+                        string imageSrcPattern = $"src.*?=.*?\"([^\"])(?=.*{att.AttOriginId}).*?\"";
                         textField = Regex.Replace(textField, imageSrcPattern, $"src=\"{tfsAtt.Uri.AbsoluteUri}\"");
                         isUpdated = true;
                     }


### PR DESCRIPTION
When multiple images were added in the description then during the migration process all images in the description were overridden by the first image. 