### PR TITLE
Added accountId to the available mappers for assignee and creator.

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -337,8 +337,8 @@ namespace JiraExport
                     {
                         { "priority", extractName },
                         { "labels", t => t.Values<string>().Any() ? string.Join(" ", t.Values<string>()) : null },
-                        { "assignee", extractName },
-                        { "creator", extractName },
+                        { "assignee", extractAccountIdOrUsername },
+                        { "creator", extractAccountIdOrUsername },
                         { "reporter", extractAccountIdOrUsername},
                         { jira.Settings.SprintField, t => string.Join(", ", ParseCustomField(jira.Settings.SprintField, t, jira)) },
                         { "status", extractName },


### PR DESCRIPTION
The returned Json for some of our users does not contain a `$.name` identifier, only a `$.displayName`. We've modified the mapping to match reporter/author, `$.name` then `$.accountId`. 

Without this fix, a null match on `$.name` which means the Assignee is ignored and not added to json output.

Our users are 1:1 via Email, so names aren't too important for us.

Proposed via PR, though I'm unsure of other potential implications?