### PR TITLE
Fixed ArgumentOutOfRangeException in JiraMapper.cs

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -225,7 +225,7 @@ namespace JiraExport
             if (r.Fields.TryGetValue(field, out object value))
             {
                 var parentKeyStr = r.OriginId.Substring(r.OriginId.LastIndexOf("-", StringComparison.InvariantCultureIgnoreCase) + 1);
-                var childKeyStr = value?.ToString().Substring(r.OriginId.LastIndexOf("-", StringComparison.InvariantCultureIgnoreCase) + 1);
+                var childKeyStr = value?.ToString().Substring((value?.ToString()).LastIndexOf("-", StringComparison.InvariantCultureIgnoreCase) + 1);
 
                 if (int.TryParse(parentKeyStr, out var parentKey) && int.TryParse(childKeyStr, out var childKey))
                 {


### PR DESCRIPTION
When exporting a Jira project that has been renamed from a short issueKey to a longer one, and that has links from one issue to another the code throws an ArgumentOutOfRangeException.  Full details are in #275 

This change fixes the calculation of the childKeyStr field