### PR TITLE
Mapping a single source to multiple targets

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -328,7 +328,7 @@ namespace JiraExport
 
                     if (item.Mapping?.Values != null)
                     {
-                        value = r => MapValue(r, item.Source);
+                        value = r => MapValue(r, item.Source, item.Target);
                     }
                     else if (!string.IsNullOrWhiteSpace(item.Mapper))
                     {
@@ -479,7 +479,7 @@ namespace JiraExport
                 return (false, null);
         }
 
-        private (bool, object) MapValue(JiraRevision r, string itemSource)
+        private (bool, object) MapValue(JiraRevision r, string itemSource, string itemTarget)
         {
             var targetWit = (from t in _config.TypeMap.Types where t.Source == r.Type select t.Target).FirstOrDefault();
 
@@ -487,7 +487,7 @@ namespace JiraExport
             {
                 foreach (var item in _config.FieldMap.Fields)
                 {
-                    if (((item.Source == itemSource && (item.For.Contains(targetWit) || item.For == "All")) ||
+                    if ((((item.Source == itemSource && item.Target == itemTarget) && (item.For.Contains(targetWit) || item.For == "All")) ||
                           item.Source == itemSource && (!string.IsNullOrWhiteSpace(item.NotFor) && !item.NotFor.Contains(targetWit))) &&
                           item.Mapping?.Values != null)
                     {


### PR DESCRIPTION
This was an issue for me, so perhaps it will be an issue for others in the future. When trying to use a single source type to create multiple target mappings I would run into the issue where the project would only grab the first map defined for a source in the config. 

My use case...
Lets say I wanted to map Jira statues to TFS/DevOps states like so...
```json
{
        "source": "status",
        "target": "System.State",
        "for": "Feature,Epic,User Story,Bug",
        "mapping": {
          "values": [
            {
              "source": "Reopened",
              "target": "Active"
            },
            {
              "source": "In Review",
              "target": "Active"
            },
            {
              "source": "Archive",
              "target": "Removed"
            }
          ]
        }
      },
```

Ontop of mapping Jira status to DevOps/TFS State, perhaps I would also like to map Jira status to DevOps/TFS reason, like so...
```
{
        "source": "status",
        "target": "System.Reason",
        "for": "Feature,Epic,User Story,Bug",
        "mapping": {
          "values": [
            {
              "source": "Reopened",
              "target": "Reactivated"
            },
            {
              "source": "Inreview",
              "target": "In Review"
            },
            {
              "source": "Archive",
              "target": "Archive"
            }
          ]
        }
      }
```