### PR TITLE
Add config setting for "maximum issue count to export"

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: solidify

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,6 +36,7 @@ The migration configuration file is defined in a json file with the properties d
 |**link-map**|True|json|List of **links** to map between Jira and Azure DevOps/TFS work item link types.|
 |**type-map**|True|json|List of the work item **types** you want to migrate from Jira to Azure DevOps/TFS.|
 |**field-map**|True|json|List of **fields** you want to migrate from a Jira item to a Azure DevOps/TFS work item.|
+|**max-issue-count**|False|integer|Maximum overall number of items to retrieve. 0 indicates all items.  Default = 0.|
 
 ## Download options
 This option allows the tool to download related issues to cover cases where these are not included in the section query (like a parent issue).

--- a/docs/config.md
+++ b/docs/config.md
@@ -37,6 +37,7 @@ The migration configuration file is defined in a json file with the properties d
 |**type-map**|True|json|List of the work item **types** you want to migrate from Jira to Azure DevOps/TFS.|
 |**field-map**|True|json|List of **fields** you want to migrate from a Jira item to a Azure DevOps/TFS work item.|
 |**max-issue-count**|False|integer|Maximum overall number of items to retrieve. 0 indicates all items.  Default = 0.|
+|**merge-labels-and-components**|False|boolean|Set to True if issues' label and component values should be merged.  Default = False.|
 
 ## Download options
 This option allows the tool to download related issues to cover cases where these are not included in the section query (like a parent issue).

--- a/src/WorkItemMigrator/JiraExport/JiraCommandLine.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraCommandLine.cs
@@ -91,7 +91,8 @@ namespace JiraExport
                     AttachmentsDir = Path.Combine(migrationWorkspace, config.AttachmentsFolder),
                     JQL = config.Query,
                     UsingJiraCloud = config.UsingJiraCloud,
-                    MaxIssueCount = config.MaxIssueCount
+                    MaxIssueCount = config.MaxIssueCount,
+                    MergeLabelsAndComponents = config.MergeLabelsAndComponents
                 };
 
                 JiraProvider jiraProvider = JiraProvider.Initialize(jiraSettings);

--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -143,14 +143,15 @@ namespace JiraExport
                 && (currentComponents.Any()))
             {
                 var mergedFields = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-                var componentList = string.Join(" ", currentComponents);
+
+                var componentList = string.Join(";", currentComponents);
                 if (string.IsNullOrWhiteSpace(currentLabels))
                 {
                     mergedFields["labels"] = componentList;
                 }
                 else
                 {
-                    mergedFields["labels"] = currentLabels + " " + componentList;
+                    mergedFields["labels"] = currentLabels + ";" + componentList;
                 }
 
                 var mergeRevision = new JiraRevision(jiraItem)
@@ -375,7 +376,7 @@ namespace JiraExport
                 _fieldExtractionMapping = new Dictionary<string, Func<JToken, object>>()
                     {
                         { "priority", extractName },
-                        { "labels", t => t.Values<string>().Any() ? string.Join(" ", t.Values<string>()) : null },
+                        { "labels", t => t.Values<string>().Any() ? string.Join(";", t.Values<string>()) : null },
                         { "components", t => t.Values().Any() ? t.SelectTokens("$..name", false).Select(x => (string)x) : null },
                         { "assignee", extractAccountIdOrUsername },
                         { "creator", extractAccountIdOrUsername },

--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -549,11 +549,7 @@ namespace JiraExport
             if (string.IsNullOrWhiteSpace(labels))
                 return null;
 
-            var tags = labels.Split(' ');
-            if (!tags.Any())
-                return null;
-            else
-                return string.Join(";", tags);
+            return labels;
         }
 
         private object MapArray(string field)

--- a/src/WorkItemMigrator/JiraExport/JiraSettings.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraSettings.cs
@@ -15,6 +15,7 @@ namespace JiraExport
         public string JQL { get; internal set; }
         public bool UsingJiraCloud { get; internal set; }
         public int MaxIssueCount { get; internal set; }
+        public bool MergeLabelsAndComponents { get; internal set; }
 
         public JiraSettings(string userID, string pass, string url, string project)
         {

--- a/src/WorkItemMigrator/JiraExport/JiraSettings.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraSettings.cs
@@ -14,6 +14,7 @@ namespace JiraExport
         public string AttachmentsDir { get; internal set; }
         public string JQL { get; internal set; }
         public bool UsingJiraCloud { get; internal set; }
+        public int MaxIssueCount { get; internal set; }
 
         public JiraSettings(string userID, string pass, string url, string project)
         {

--- a/src/WorkItemMigrator/Migration.Common.Log/Logger.cs
+++ b/src/WorkItemMigrator/Migration.Common.Log/Logger.cs
@@ -26,6 +26,7 @@ namespace Migration.Common.Log
         private static List<string> _warnings = new List<string>();
         private static TelemetryClient _telemetryClient = null;
         private static bool? _continueOnCritical;
+        public static int NumberOfIssuesExported { get; set; }
 
         static Logger()
         {

--- a/src/WorkItemMigrator/Migration.Common/Config/ConfigJson.cs
+++ b/src/WorkItemMigrator/Migration.Common/Config/ConfigJson.cs
@@ -69,5 +69,8 @@ namespace Common.Config
 
         [JsonProperty(PropertyName = "max-issue-count")]
         public int MaxIssueCount { get; set; } = 0;
+
+        [JsonProperty(PropertyName = "merge-labels-and-components")]
+        public bool MergeLabelsAndComponents { get; set; } = false;
     }
 }

--- a/src/WorkItemMigrator/Migration.Common/Config/ConfigJson.cs
+++ b/src/WorkItemMigrator/Migration.Common/Config/ConfigJson.cs
@@ -66,5 +66,8 @@ namespace Common.Config
 
         [JsonProperty(PropertyName = "using-jira-cloud")]
         public bool UsingJiraCloud { get; set; } = true;
+
+        [JsonProperty(PropertyName = "max-issue-count")]
+        public int MaxIssueCount { get; set; } = 0;
     }
 }


### PR DESCRIPTION
Since JQL cannot be used to limit the number of issues to export, I would like to add a setting for "max-issues-count".  This helps in testing before exporting potentially thousands of issues.