### PR TITLE
Update JiraProvider.cs

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraProvider.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraProvider.cs
@@ -131,6 +131,7 @@ namespace JiraExport
                         var path = Path.Combine(Settings.AttachmentsDir, att.Id, att.Filename);
                         EnsurePath(path);
 
+                        att.Url = att?.Url?.Replace("+", "%20");
                         await DownloadWithJiraRestClientAsync(att.Url, path);
 
                         att.LocalPath = path;


### PR DESCRIPTION
Fixes bug when migrating attachments with a space in their filenames. These were not being downloaded successfully.