### PR TITLE
Include required runtime assembly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,7 @@ steps:
         Microsoft.TeamFoundation.WorkItemTracking.Common.dll
         Microsoft.TeamFoundation.WorkItemTracking.Proxy.dll
         Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
+        Microsoft.VisualStudio.Services.Client.Interactive.dll
         Microsoft.VisualStudio.Services.Common.dll
         Microsoft.VisualStudio.Services.WebApi.dll
         Microsoft.WITDataStore32.dll


### PR DESCRIPTION
Here is a small fix to the Azure DevOps pipeline for you to consider. It adds a runtime required assembly for the Work Item Importer to the WorkIemMigrator.zip build artifact.

fixes #513