### PR TITLE
Set FileName as attachment name instead of FilePath

### DIFF
--- a/src/WorkItemMigrator/Migration.WIContract/WiAttachment.cs
+++ b/src/WorkItemMigrator/Migration.WIContract/WiAttachment.cs
@@ -1,14 +1,27 @@
 ﻿using System.IO;
-using System;
 
 namespace Migration.WIContract
 {
     public class WiAttachment
     {
         public ReferenceChangeType Change { get; set; }
-        public string FilePath { get; set; }
+        public string FileName { get; private set; }
         public string Comment { get; set; }
         public string AttOriginId { get; set; }
+
+        private string filePath;
+        public string FilePath
+        {
+            get
+            {
+                return filePath;
+            }
+            set
+            {
+                filePath = value;
+                FileName = Path.GetFileName(value);
+            }
+        }
 
         public override string ToString()
         {

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/IWitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/IWitClientWrapper.cs
@@ -2,6 +2,7 @@
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
+using Migration.WIContract;
 
 namespace WorkItemImport
 {
@@ -12,6 +13,6 @@ namespace WorkItemImport
         WorkItem UpdateWorkItem(JsonPatchDocument patchDocument, int workItemId);
         TeamProject GetProject(string projectId);
         List<WorkItemRelationType> GetRelationTypes();
-        AttachmentReference CreateAttachment(string filePath);
+        AttachmentReference CreateAttachment(WiAttachment attachment);
     }
 }

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -596,7 +596,7 @@ namespace WorkItemImport
         private void AddSingleAttachmentToWorkItemAndSave(WiAttachment att, WorkItem wi)
         {
             // Upload attachment
-            AttachmentReference attachment = _witClientWrapper.CreateAttachment(att.FilePath);
+            AttachmentReference attachment = _witClientWrapper.CreateAttachment(att);
             Logger.Log(LogLevel.Info, "Attachment created");
             Logger.Log(LogLevel.Info, $"ID: { attachment.Id}");
             Logger.Log(LogLevel.Info, $"URL: '{attachment.Url}'");

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
@@ -94,9 +96,10 @@ namespace WorkItemImport
             return WitClient.GetRelationTypesAsync().Result;
         }
 
-        public AttachmentReference CreateAttachment(string filePath)
+        public AttachmentReference CreateAttachment(WiAttachment attachment)
         {
-            return WitClient.CreateAttachmentAsync(filePath).Result;
+            using (FileStream uploadStream = File.Open(attachment.FilePath, FileMode.Open, FileAccess.Read))
+                return WitClient.CreateAttachmentAsync(uploadStream, attachment.FileName, null, null, null, new CancellationToken()).Result;
         }
     }
 }

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -124,7 +124,7 @@ namespace Migration.Wi_Import.Tests
                 return outList;
             }
 
-            public AttachmentReference CreateAttachment(string filePath)
+            public AttachmentReference CreateAttachment(WiAttachment wiAttachment)
             {
                 AttachmentReference att = new AttachmentReference();
                 att.Id = Guid.NewGuid();


### PR DESCRIPTION
Attachments are currently added with the fullPath of the uploaded file as the attachment name in DevOps. It would be nicer (and in line with the released version) to use the fileName. 
This PR changes the attachment name to the FileName, the attachment comment still contains the fullPath.