### PR TITLE
Bugfix/remove jira links from initial revision

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -33,7 +33,7 @@ namespace JiraExport
 
         }
 
-        public static List<JiraRevision> BuildRevisions(JiraItem jiraItem, IJiraProvider jiraProvider)
+        private static List<JiraRevision> BuildRevisions(JiraItem jiraItem, IJiraProvider jiraProvider)
         {
             string issueKey = jiraItem.Key;
             var remoteIssue = jiraItem.RemoteIssue;

--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -33,13 +33,14 @@ namespace JiraExport
 
         }
 
-        private static List<JiraRevision> BuildRevisions(JiraItem jiraItem, IJiraProvider jiraProvider)
+        public static List<JiraRevision> BuildRevisions(JiraItem jiraItem, IJiraProvider jiraProvider)
         {
             string issueKey = jiraItem.Key;
             var remoteIssue = jiraItem.RemoteIssue;
             Dictionary<string, object> fields = ExtractFields(issueKey, remoteIssue, jiraProvider);
             List<JiraAttachment> attachments = ExtractAttachments(remoteIssue.SelectTokens("$.fields.attachment[*]").Cast<JObject>()) ?? new List<JiraAttachment>();
             List<JiraLink> links = ExtractLinks(issueKey, remoteIssue.SelectTokens("$.fields.issuelinks[*]").Cast<JObject>()) ?? new List<JiraLink>();
+            var epicLinkField = jiraProvider.GetSettings().EpicLinkField;
 
             // save these field since these might be removed in the loop
             string reporter = GetAuthor(fields);
@@ -66,9 +67,28 @@ namespace JiraExport
                 Dictionary<string, object> fieldChanges = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
 
                 var items = change.SelectTokens("$.items[*]")?.Cast<JObject>()?.Select(i => new JiraChangeItem(i));
-
                 foreach (var item in items)
                 {
+                    if (item.Field == "Epic Link" && !string.IsNullOrWhiteSpace(epicLinkField))
+                    {
+                        fieldChanges[epicLinkField] = item.ToString;
+
+                        // undo field change
+                        if (string.IsNullOrWhiteSpace(item.From))
+                            fields.Remove(epicLinkField);
+                        else
+                            fields[epicLinkField] = item.FromString;
+                    }
+                    if (item.Field == "Parent")
+                    {
+                        fieldChanges["parent"] = item.ToString;
+
+                        // undo field change
+                        if (string.IsNullOrWhiteSpace(item.From))
+                            fields.Remove("parent");
+                        else
+                            fields["parent"] = item.FromString;
+                    }
                     if (item.Field == "Link")
                     {
                         var linkChange = TransformLinkChange(item, issueKey, jiraProvider);
@@ -142,7 +162,7 @@ namespace JiraExport
             var author = "NoAuthorDefined";
             if (c.AuthorUser is null)
             {
-                Logger.Log(LogLevel.Warning, $"c.AuthorUser is null in comment revision for jiraItem.Key: '{ jiraItem.Key}'. Using NoAuthorDefined as author. ");
+                Logger.Log(LogLevel.Warning, $"c.AuthorUser is null in comment revision for jiraItem.Key: '{jiraItem.Key}'. Using NoAuthorDefined as author. ");
             }
             else
             {
@@ -258,7 +278,6 @@ namespace JiraExport
             else
                 Logger.Log(LogLevel.Debug, $"No link to undo for '{linkChange.ToString()}'");
         }
-
         private static RevisionAction<JiraLink> TransformLinkChange(JiraChangeItem item, string sourceItemKey, IJiraProvider jira)
         {
             string targetItemKey = string.Empty;
@@ -282,7 +301,6 @@ namespace JiraExport
                 Logger.Log(LogLevel.Error, $"Link change not handled!");
                 return null;
             }
-
             var linkType = jira.GetLinkType(linkTypeString, targetItemKey);
             if (linkType == null)
             {

--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -79,7 +79,7 @@ namespace JiraExport
                         else
                             fields[epicLinkField] = item.FromString;
                     }
-                    if (item.Field == "Parent")
+                    else if (item.Field == "Parent")
                     {
                         fieldChanges["parent"] = item.ToString;
 
@@ -89,7 +89,7 @@ namespace JiraExport
                         else
                             fields["parent"] = item.FromString;
                     }
-                    if (item.Field == "Link")
+                    else if (item.Field == "Link")
                     {
                         var linkChange = TransformLinkChange(item, issueKey, jiraProvider);
                         if (linkChange == null)

--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -79,7 +79,7 @@ namespace JiraExport
                         else
                             fields[epicLinkField] = item.FromString;
                     }
-                    else if (item.Field == "Parent")
+                    else if (item.Field == "Parent" || item.Field == "IssueParentAssociation")
                     {
                         fieldChanges["parent"] = item.ToString;
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/HistoryItem.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/HistoryItem.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+
+namespace Migration.Jira_Export.Tests
+{
+    public class HistoryItem
+    {
+        public long Id { get; set; } = 0;
+        public DateTime Created { get; set; } = DateTime.Now;
+        public string Field { get; set; } = string.Empty;
+        public string FieldType { get; set; } = string.Empty;
+        public string From { get; set; } = string.Empty;
+        public string FromString { get; set; } = string.Empty;
+        public string To { get; set; } = string.Empty;
+        public new string ToString { get; set; } = string.Empty;
+
+        public JObject ToJObject()
+        {
+            return JObject.Parse($@"
+            {{
+                'id': {Id},
+                'author': 'unittest',
+                'created': '{Created.ToString("yyyy - MM - ddTHH:mm: ss.fffZ")}',
+                'items': [
+                {{
+                  'field': '{Field}',
+                  'fieldtype': '{FieldType}',
+                  'from': '{From}',
+                  'fromString': '{FromString}',
+                  'to': '{To}',
+                  'toString': '{ToString}'
+                }}
+              ]
+            }}");
+        }
+    }
+}

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
@@ -1,0 +1,434 @@
+﻿using NUnit.Framework;
+
+using JiraExport;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+
+namespace Migration.Jira_Export.Tests
+{
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class JiraItemTests
+    {
+        // use auto fixture to help mock and instantiate with dummy data with nsubsitute. 
+        private Fixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = new Fixture();
+            _fixture.Customize(new AutoNSubstituteCustomization() { });
+        }
+
+        [Test]
+        public void When_a_parent_link_is_added_later_Then_it_should_not_be_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string parentId = _fixture.Create<long>().ToString();
+            string parentKey = "ISSUE-xx";
+
+            var fields = JObject.Parse($@"{{
+                'issuetype': {{ 'name': 'Story' }},
+                'parent': {{ 'id': '{parentId}', 'key': '{parentKey}' }}
+            }}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Parent",
+                    FieldType = "jira",
+                    To = parentId,
+                    ToString = parentKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
+            Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey("parent"));
+        }
+
+        [Test]
+        public void When_a_parent_link_is_changed_later_Then_it_should_not_be_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string previousParentId = _fixture.Create<long>().ToString();
+            string previousParentKey = "ISSUE-xx";
+            string currentParentId = _fixture.Create<long>().ToString();
+            string currentParentKey = "ISSUE-yy";
+
+            var fields = JObject.Parse($@"{{
+                'issuetype': {{ 'name': 'Story' }},
+                'parent': {{ 'id': '{currentParentId}', 'key': '{currentParentKey}' }}
+            }}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Parent",
+                    FieldType = "jira",
+                    From = previousParentId,
+                    FromString = previousParentKey,
+                    To = currentParentId,
+                    ToString = currentParentKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.AreEqual(previousParentKey, jiraItem.Revisions[0].Fields["parent"]);
+            Assert.AreEqual(currentParentKey, jiraItem.Revisions[1].Fields["parent"]);
+        }
+
+        [Test]
+        public void When_a_parent_link_is_added_and_changed_later_Then_it_should_not_be_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string previousParentId = _fixture.Create<long>().ToString();
+            string previousParentKey = "PreviousParentKey";
+            string currentParentId = _fixture.Create<long>().ToString();
+            string currentParentKey = "CurrentParentKey";
+
+            var fields = JObject.Parse($@"{{
+                'issuetype': {{ 'name': 'Story' }}
+            }}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() {
+                new HistoryItem() 
+                {
+                    Id = 0,
+                    Field = "Parent",
+                    FieldType = "jira",
+                    To = previousParentId,
+                    ToString = previousParentKey
+                }.ToJObject(), 
+                new HistoryItem() 
+                {
+                    Id = 1,
+                    Field = "Parent",
+                    FieldType = "jira",
+                    From = previousParentId,
+                    FromString = previousParentKey,
+                    To = currentParentId,
+                    ToString = currentParentKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
+            Assert.AreEqual(previousParentKey, jiraItem.Revisions[1].Fields["parent"]);
+            Assert.AreEqual(currentParentKey, jiraItem.Revisions[2].Fields["parent"]);
+        }
+
+        [Test]
+        public void When_a_parent_link_was_removed_Then_the_result_should_be_succesful()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string previousParentId = _fixture.Create<long>().ToString();
+            string previousParentKey = "ISSUE-xx";
+
+            var fields = JObject.Parse($@"{{
+                'issuetype': {{ 'name': 'Story' }}
+            }}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Parent",
+                    FieldType = "jira",
+                    From = previousParentId,
+                    FromString = previousParentKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.AreEqual(2, jiraItem.Revisions.Count);
+        }
+
+        [Test]
+        public void When_an_epic_link_is_added_later_Then_it_should_not_be_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string epicId = _fixture.Create<long>().ToString();
+            string epicKey = "EpicKey";
+
+            var fields = JObject.Parse(@"{
+                'issuetype': {'name': 'Story'},
+                'EpicLinkField': 'EpicKey'
+            }");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    To = epicId,
+                    ToString = epicKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
+            Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey(jiraSettings.EpicLinkField));
+        }
+
+        [Test]
+        public void When_an_epic_link_is_changed_Then_it_should_have_the_previous_value_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string currentEpicId = _fixture.Create<long>().ToString();
+            string currentEpicKey = "EpicKey";
+            string previousEpicId = _fixture.Create<long>().ToString();
+            string previousEpicKey = "PreviousEpicKey";
+
+            var fields = JObject.Parse(@"{'issuetype': {'name': 'Story'},'EpicLinkField': 'EpicKey'}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    From = previousEpicId,
+                    FromString = previousEpicKey,
+                    To = currentEpicId,
+                    ToString = currentEpicKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.AreEqual(previousEpicKey,jiraItem.Revisions[0].Fields[jiraSettings.EpicLinkField]);
+            Assert.AreEqual(currentEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
+        }
+
+        [Test]
+        public void When_an_epic_link_is__added_and_changed_later_Then_it_should_not_be_in_the_initial_revision()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string currentEpicId = _fixture.Create<long>().ToString();
+            string currentEpicKey = "EpicKey";
+            string previousEpicId = _fixture.Create<long>().ToString();
+            string previousEpicKey = "PreviousEpicKey";
+
+            var fields = JObject.Parse(@"{'issuetype': {'name': 'Story'},'EpicLinkField': null}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    To = previousEpicId,
+                    ToString = previousEpicKey
+                }.ToJObject(), 
+                new HistoryItem()
+                {
+                    Id = 1,
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    From = previousEpicId,
+                    FromString = previousEpicKey,
+                    To = currentEpicId,
+                    ToString = currentEpicKey
+                }.ToJObject()
+             };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
+            Assert.AreEqual(previousEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
+            Assert.AreEqual(currentEpicKey, jiraItem.Revisions[2].Fields[jiraSettings.EpicLinkField]);
+        }
+
+        [Test]
+        public void When_an_epic_link_was_removed_Then_the_result_should_be_successful()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string previousEpicId = _fixture.Create<long>().ToString();
+            string previousEpicKey = "PreviousEpicKey";
+
+            var fields = JObject.Parse(@"{'issuetype': {'name': 'Story'},'EpicLinkField': 'EpicKey'}");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    From = previousEpicId,
+                    FromString = previousEpicKey
+                }.ToJObject() 
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+
+            //Act
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+
+            //Assert
+            Assert.AreEqual(2, jiraItem.Revisions.Count);
+        }
+
+        private JiraSettings createJiraSettings()
+        {
+            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            settings.EpicLinkField = "EpicLinkField";
+            settings.SprintField = "SprintField";
+
+            return settings;
+        }
+    }
+}

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
@@ -67,8 +67,11 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
-            Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey("parent"));
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
+                Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey("parent"));
+            });
         }
 
         [Test]
@@ -118,8 +121,11 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.AreEqual(previousParentKey, jiraItem.Revisions[0].Fields["parent"]);
-            Assert.AreEqual(currentParentKey, jiraItem.Revisions[1].Fields["parent"]);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(previousParentKey, jiraItem.Revisions[0].Fields["parent"]);
+                Assert.AreEqual(currentParentKey, jiraItem.Revisions[1].Fields["parent"]);
+            });
         }
 
         [Test]
@@ -177,9 +183,12 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
-            Assert.AreEqual(previousParentKey, jiraItem.Revisions[1].Fields["parent"]);
-            Assert.AreEqual(currentParentKey, jiraItem.Revisions[2].Fields["parent"]);
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey("parent"));
+                Assert.AreEqual(previousParentKey, jiraItem.Revisions[1].Fields["parent"]);
+                Assert.AreEqual(currentParentKey, jiraItem.Revisions[2].Fields["parent"]);
+            });
         }
 
         [Test]
@@ -224,7 +233,10 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.AreEqual(2, jiraItem.Revisions.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(2, jiraItem.Revisions.Count);
+            });
         }
 
         [Test]
@@ -270,8 +282,11 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
-            Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey(jiraSettings.EpicLinkField));
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
+                Assert.IsTrue(jiraItem.Revisions[1].Fields.ContainsKey(jiraSettings.EpicLinkField));
+            });
         }
 
         [Test]
@@ -318,8 +333,11 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.AreEqual(previousEpicKey,jiraItem.Revisions[0].Fields[jiraSettings.EpicLinkField]);
-            Assert.AreEqual(currentEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(previousEpicKey, jiraItem.Revisions[0].Fields[jiraSettings.EpicLinkField]);
+                Assert.AreEqual(currentEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
+            });
         }
 
         [Test]
@@ -374,9 +392,12 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
-            Assert.AreEqual(previousEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
-            Assert.AreEqual(currentEpicKey, jiraItem.Revisions[2].Fields[jiraSettings.EpicLinkField]);
+            Assert.Multiple(() =>
+            {
+                Assert.IsFalse(jiraItem.Revisions[0].Fields.ContainsKey(jiraSettings.EpicLinkField));
+                Assert.AreEqual(previousEpicKey, jiraItem.Revisions[1].Fields[jiraSettings.EpicLinkField]);
+                Assert.AreEqual(currentEpicKey, jiraItem.Revisions[2].Fields[jiraSettings.EpicLinkField]);
+            });
         }
 
         [Test]
@@ -419,7 +440,10 @@ namespace Migration.Jira_Export.Tests
             var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
 
             //Assert
-            Assert.AreEqual(2, jiraItem.Revisions.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(2, jiraItem.Revisions.Count);
+            });
         }
 
         private JiraSettings createJiraSettings()

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
@@ -115,12 +115,15 @@ namespace Migration.Jira_Export.Tests
             WiItem actual = sut.Map(jiraItem);
 
             //Assert
-            Assert.AreEqual(3, actual.Revisions.Count());
-            Assert.AreEqual(0, actual.Revisions[0].Links.Count());
-            Assert.AreEqual(1, actual.Revisions[1].Links.Count());
-            Assert.AreEqual(epicKey, actual.Revisions[1].Links[0].TargetOriginId);
-            Assert.AreEqual(1, actual.Revisions[2].Links.Count());
-            Assert.AreEqual(parentKey, actual.Revisions[2].Links[0].TargetOriginId);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(3, actual.Revisions.Count());
+                Assert.AreEqual(0, actual.Revisions[0].Links.Count());
+                Assert.AreEqual(1, actual.Revisions[1].Links.Count());
+                Assert.AreEqual(epicKey, actual.Revisions[1].Links[0].TargetOriginId);
+                Assert.AreEqual(1, actual.Revisions[2].Links.Count());
+                Assert.AreEqual(parentKey, actual.Revisions[2].Links[0].TargetOriginId);
+            });
         }
 
         [Test]

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
@@ -11,6 +11,8 @@ using Migration.Common.Config;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using System.Diagnostics.CodeAnalysis;
+using Type = Migration.Common.Config.Type;
+using System.Linq;
 
 namespace Migration.Jira_Export.Tests
 {
@@ -56,6 +58,69 @@ namespace Migration.Jira_Export.Tests
             JiraMapper sut = createJiraMapper();
 
             Assert.Throws<System.ArgumentNullException>(() => { sut.Map(null); });
+        }
+
+        [Test]
+        public void When_calling_map_on_an_issue_with_an_epic_link_and_a_parent_Then_two_parent_links_are_mapped()
+        {
+            //Arrange
+            var provider = _fixture.Freeze<IJiraProvider>();
+            long issueId = _fixture.Create<long>();
+            string issueKey = _fixture.Create<string>();
+            string epicId = _fixture.Create<long>().ToString();
+            string epicKey = "EpicKey";
+            string parentId = _fixture.Create<long>().ToString();
+            string parentKey = "ParentKey";
+
+            var fields = JObject.Parse(@"{
+                'issuetype': {'name': 'Story'},
+                'EpicLinkField': 'EpicKey'
+            }");
+            var renderedFields = JObject.Parse("{ 'custom_field_name': 'SomeValue', 'description': 'RenderedDescription' }");
+
+            var changelog = new List<JObject>() { 
+                new HistoryItem() 
+                {
+                    Field = "Epic Link",
+                    FieldType = "custom",
+                    To = epicId,
+                    ToString = epicKey
+                }.ToJObject(),
+                new HistoryItem() 
+                {
+                    Id = 1,
+                    Field = "Parent",
+                    FieldType = "jira",
+                    To = parentId,
+                    ToString = parentKey
+                }.ToJObject()
+            };
+
+            JObject remoteIssue = new JObject
+            {
+                { "id", issueId },
+                { "key", issueKey },
+                { "fields", fields },
+                { "renderedFields", renderedFields }
+            };
+
+            provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
+            provider.DownloadChangelog(default).ReturnsForAnyArgs(changelog);
+            var jiraSettings = createJiraSettings();
+            provider.GetSettings().ReturnsForAnyArgs(jiraSettings);
+            var jiraItem = JiraItem.CreateFromRest(issueKey, provider);
+            JiraMapper sut = createJiraMapper();
+
+            //Act
+            WiItem actual = sut.Map(jiraItem);
+
+            //Assert
+            Assert.AreEqual(3, actual.Revisions.Count());
+            Assert.AreEqual(0, actual.Revisions[0].Links.Count());
+            Assert.AreEqual(1, actual.Revisions[1].Links.Count());
+            Assert.AreEqual(epicKey, actual.Revisions[1].Links[0].TargetOriginId);
+            Assert.AreEqual(1, actual.Revisions[2].Links.Count());
+            Assert.AreEqual(parentKey, actual.Revisions[2].Links[0].TargetOriginId);
         }
 
         [Test]
@@ -158,16 +223,25 @@ namespace Migration.Jira_Export.Tests
             provider.GetSettings().ReturnsForAnyArgs(createJiraSettings());
 
             ConfigJson cjson = new ConfigJson();
-            TypeMap t = new TypeMap();
-            t.Types = new List<Type>();
+            
             FieldMap f = new FieldMap();
             f.Fields = new List<Field>();
-            cjson.TypeMap = t;
+            cjson.FieldMap = f;
+
+            TypeMap t = new TypeMap();
+            t.Types = new List<Type>();
             Type type = new Type();
             type.Source = "Story";
             type.Target = "User Story";
             t.Types.Add(type);
-            cjson.FieldMap = f;
+            cjson.TypeMap = t;
+
+            LinkMap linkMap = new LinkMap();
+            linkMap.Links = new List<Link>();
+            var epicLinkMap = new Link() { Source = "Epic", Target = "System.LinkTypes.Hierarchy-Reverse" };
+            var parentLinkMap = new Link() { Source = "Parent", Target = "System.LinkTypes.Hierarchy-Reverse" };
+            linkMap.Links.AddRange(new Link[] { epicLinkMap, parentLinkMap });
+            cjson.LinkMap = linkMap;
 
             JiraMapper sut = new JiraMapper(provider, cjson);
 


### PR DESCRIPTION
This PR handles historical items from the changelog where it concerns the fields "Epic Link" and "Parent" so that they are removed from the initial revision.

Unittests will fail until #559 is fixed :)
Fixes #563