### PR TITLE
Fix attachments in comments

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -729,7 +729,7 @@ namespace WorkItemImport
         {
             if (isAttachmentMigratedDelegate(att.AttOriginId, out string attWiId))
             {
-                return wi.Relations.SingleOrDefault(a => a.Rel == "AttachedFile" && a.Attributes["filePath"].ToString() == att.FilePath);
+                return wi.Relations.SingleOrDefault(a => a.Rel == "AttachedFile" && a.Attributes["comment"].ToString().Split('|')[1] == att.FilePath);
             }
             return null;
         }

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -360,11 +360,10 @@ namespace WorkItemImport
                 WorkItemRelation attachmentRelation = new WorkItemRelation();
                 attachmentRelation.Rel = "AttachedFile";
                 attachmentRelation.Attributes = new Dictionary<string, object>();
-                attachmentRelation.Attributes["filePath"] = filePath;
                 attachmentRelation.Attributes["comment"] = comment;
                 wi.Relations.Add(attachmentRelation);
             } else {
-                WorkItemRelation attachmentRelation = wi.Relations.FirstOrDefault(e => e.Rel == "AttachedFile" && e.Attributes["filePath"].ToString() == filePath);
+                WorkItemRelation attachmentRelation = wi.Relations.FirstOrDefault(e => e.Rel == "AttachedFile" && e.Attributes["comment"].ToString().Split('|')[1] == filePath);
                 if(attachmentRelation != default(WorkItemRelation))
                 {
                     wi.Relations.Remove(attachmentRelation);

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -308,7 +308,7 @@ namespace WorkItemImport
                     Logger.Log(LogLevel.Debug, $"Adding attachment '{att.ToString()}'.");
                     if (att.Change == ReferenceChangeType.Added)
                     {
-                        AddRemoveAttachment(wi, att.FilePath, att.Comment, AttachmentOperation.ADD);
+                        AddRemoveAttachment(wi, att.AttOriginId, att.Comment, AttachmentOperation.ADD);
 
                         attachmentMap.Add(att.AttOriginId, att);
                     }
@@ -317,7 +317,7 @@ namespace WorkItemImport
                         WorkItemRelation existingAttachment = IdentifyAttachment(att, wi, isAttachmentMigratedDelegate);
                         if (existingAttachment != null)
                         {
-                            AddRemoveAttachment(wi, att.FilePath, att.Comment, AttachmentOperation.REMOVE);
+                            AddRemoveAttachment(wi, att.AttOriginId, att.Comment, AttachmentOperation.REMOVE);
                         }
                         else
                         {
@@ -349,7 +349,7 @@ namespace WorkItemImport
             REMOVE
         }
 
-        private void AddRemoveAttachment(WorkItem wi, string filePath, string comment, AttachmentOperation op)
+        private void AddRemoveAttachment(WorkItem wi, string attOriginId, string comment, AttachmentOperation op)
         {
             if (wi == null)
             {
@@ -363,7 +363,11 @@ namespace WorkItemImport
                 attachmentRelation.Attributes["comment"] = comment;
                 wi.Relations.Add(attachmentRelation);
             } else {
-                WorkItemRelation attachmentRelation = wi.Relations.FirstOrDefault(e => e.Rel == "AttachedFile" && e.Attributes["comment"].ToString().Split('|')[1] == filePath);
+                WorkItemRelation attachmentRelation = wi.Relations.FirstOrDefault(
+                    a => a.Rel == "AttachedFile" &&
+                    a.Attributes["comment"].ToString().Split(
+                        new string[] { ", original ID: " }, StringSplitOptions.None)[1] == attOriginId
+                );
                 if(attachmentRelation != default(WorkItemRelation))
                 {
                     wi.Relations.Remove(attachmentRelation);
@@ -583,7 +587,7 @@ namespace WorkItemImport
                         url = attachment.Url,
                         attributes = new
                         {
-                            comment = $"{att.Comment}|{att.FilePath}"
+                            comment = $"{att.Comment}, original ID: {att.AttOriginId}"
                         }
                     }
                 }
@@ -609,8 +613,9 @@ namespace WorkItemImport
         {
             WorkItemRelation existingAttachmentRelation =
                 wi.Relations?.SingleOrDefault(
-                    r => r.Rel == "AttachedFile"
-                    && r.Attributes["comment"].ToString().Split('|').Last() == att.FilePath
+                    a => a.Rel == "AttachedFile" &&
+                    a.Attributes["comment"].ToString().Split(
+                        new string[] { ", original ID: " }, StringSplitOptions.None)[1] == att.AttOriginId
                 );
 
             if(existingAttachmentRelation == null)
@@ -728,7 +733,11 @@ namespace WorkItemImport
         {
             if (isAttachmentMigratedDelegate(att.AttOriginId, out string attWiId))
             {
-                return wi.Relations.SingleOrDefault(a => a.Rel == "AttachedFile" && a.Attributes["comment"].ToString().Split('|')[1] == att.FilePath);
+                return wi.Relations.SingleOrDefault(
+                    a => a.Rel == "AttachedFile" &&
+                    a.Attributes["comment"].ToString().Split(
+                        new string[] { ", original ID: " }, StringSplitOptions.None)[1] == att.AttOriginId
+                );
             }
             return null;
         }

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -748,7 +748,6 @@ namespace Migration.Wi_Import.Tests
             wiUtils.ApplyAttachments(revision, createdWI, attachmentMap, MockedIsAttachmentMigratedDelegateTrue);
 
             Assert.That(createdWI.Relations[0].Rel, Is.EqualTo("AttachedFile"));
-            Assert.That(createdWI.Relations[0].Attributes["filePath"], Is.EqualTo(att.FilePath));
             Assert.That(createdWI.Relations[0].Attributes["comment"], Is.EqualTo(att.Comment));
         }
 

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -606,7 +606,7 @@ namespace Migration.Wi_Import.Tests
         [Test]
         public void When_calling_correct_comment_with_valid_args_Then_history_is_updated_with_correct_image_urls()
         {
-            string commentBeforeTransformation = "My comment, including file: <img src=\"my_image.png\">";
+            string commentBeforeTransformation = "My comment, including file: <img src=\"C:\\Temp\\workspace\\Attachments\\100\\my_image.png\">";
             string commentAfterTransformation = "My comment, including file: <img src=\"https://example.com/my_image.png\">";
 
             MockedWitClientWrapper witClientWrapper = new MockedWitClientWrapper();
@@ -617,12 +617,15 @@ namespace Migration.Wi_Import.Tests
             createdWI.Relations.Add(new WorkItemRelation() {
                 Rel= "AttachedFile",
                 Url= "https://example.com/my_image.png",
-                Attributes = new Dictionary<string, object>() { { "filePath", "C:\\Temp\\MyFiles\\my_image.png" } }
+                Attributes = new Dictionary<string, object>() {
+                    { "comment", "Imported from Jira, original ID: 100" }
+                }
             });
 
             WiAttachment att = new WiAttachment();
             att.Change = ReferenceChangeType.Added;
-            att.FilePath = "C:\\Temp\\MyFiles\\my_image.png";
+            att.FilePath = "C:\\Temp\\workspace\\Attachments\\100\\my_image.png";
+            att.AttOriginId = "100";
 
             WiRevision revision = new WiRevision();
             revision.Attachments.Add(att);
@@ -650,7 +653,7 @@ namespace Migration.Wi_Import.Tests
         [Test]
         public void When_calling_correct_description_for_user_story_Then_description_is_updated_with_correct_image_urls()
         {
-            string descriptionBeforeTransformation = "My description, including file: <img src=\"my_image.png\">";
+            string descriptionBeforeTransformation = "My description, including file: <img src=\"C:\\Temp\\workspace\\Attachments\\100\\my_image.png\">";
             string descriptionAfterTransformation = "My description, including file: <img src=\"https://example.com/my_image.png\">";
 
             MockedWitClientWrapper witClientWrapper = new MockedWitClientWrapper();
@@ -662,12 +665,15 @@ namespace Migration.Wi_Import.Tests
             {
                 Rel = "AttachedFile",
                 Url = "https://example.com/my_image.png",
-                Attributes = new Dictionary<string, object>() { { "filePath", "C:\\Temp\\MyFiles\\my_image.png" } }
+                Attributes = new Dictionary<string, object>() { 
+                    { "comment", "Imported from Jira, original ID: 100" }
+                }
             });
 
             WiAttachment att = new WiAttachment();
             att.Change = ReferenceChangeType.Added;
-            att.FilePath = "C:\\Temp\\MyFiles\\my_image.png";
+            att.FilePath = "C:\\Temp\\workspace\\Attachments\\100\\my_image.png";
+            att.AttOriginId = "100";
 
             WiRevision revision = new WiRevision();
             revision.Attachments.Add(att);
@@ -684,7 +690,7 @@ namespace Migration.Wi_Import.Tests
         [Test]
         public void When_calling_correct_description_for_bug_Then_repro_steps_is_updated_with_correct_image_urls()
         {
-            string reproStepsBeforeTransformation = "My description, including file: <img src=\"my_image.png\">";
+            string reproStepsBeforeTransformation = "My description, including file: <img src=\"C:\\Temp\\workspace\\Attachments\\100\\my_image.png\">";
             string reproStepsAfterTransformation = "My description, including file: <img src=\"https://example.com/my_image.png\">";
 
             MockedWitClientWrapper witClientWrapper = new MockedWitClientWrapper();
@@ -696,12 +702,15 @@ namespace Migration.Wi_Import.Tests
             {
                 Rel = "AttachedFile",
                 Url = "https://example.com/my_image.png",
-                Attributes = new Dictionary<string, object>() { { "filePath", "C:\\Temp\\MyFiles\\my_image.png" } }
+                Attributes = new Dictionary<string, object>() {
+                    { "comment", "Imported from Jira, original ID: 100" }
+                }
             });
 
             WiAttachment att = new WiAttachment();
             att.Change = ReferenceChangeType.Added;
-            att.FilePath = "C:\\Temp\\MyFiles\\my_image.png";
+            att.FilePath = "C:\\Temp\\workspace\\Attachments\\100\\my_image.png";
+            att.AttOriginId = "100";
 
             WiRevision revision = new WiRevision();
             revision.Attachments.Add(att);
@@ -764,7 +773,7 @@ namespace Migration.Wi_Import.Tests
             {
                 Rel = "AttachedFile",
                 Url = "https://example.com/my_image.png",
-                Attributes = new Dictionary<string, object>() { { "filePath", attachmentFilePath } }
+                Attributes = new Dictionary<string, object>() { { "comment", "Imported from Jira, original ID: 100" } }
             });
 
             WiAttachment att = new WiAttachment();

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -871,8 +871,8 @@ namespace Migration.Wi_Import.Tests
 
             Assert.That(createdWI.Relations[0].Rel, Is.EqualTo("AttachedFile"));
             Assert.That(createdWI.Relations[0].Url, Is.EqualTo("https://example.com"));
-            Assert.That(createdWI.Relations[0].Attributes["comment"].ToString().Split('|')[0], Is.EqualTo(att.Comment));
-            Assert.That(createdWI.Relations[0].Attributes["comment"].ToString().Split('|')[1], Is.EqualTo(att.FilePath));
+            Assert.That(createdWI.Relations[0].Attributes["comment"].ToString().Split(", original ID: ")[0], Is.EqualTo(att.Comment));
+            Assert.That(createdWI.Relations[0].Attributes["comment"].ToString().Split(", original ID: ")[1], Is.EqualTo(att.AttOriginId));
 
         }
     }


### PR DESCRIPTION
Fixes #562 and #510

The problem was that ADO does not support adding filePath to the Relation attributes.

Long ago, we decided not to pass the full file path as the fileName any longer, and in the same PR we added the filePath into the comment attribute. See this picture:

![image](https://user-images.githubusercontent.com/10683896/197720327-1c0791d0-1c44-4a0e-98cc-3c188cc49d4c.png)

This PR will make it so that the importer identifies the attachment by its filePath taken from the comment attribute.

Tested locally and everything works.

### Before (JIRA)

![image](https://user-images.githubusercontent.com/10683896/197723590-67583a63-e731-4dd3-b6fd-177705ec7538.png)

### After (ADO)

![image](https://user-images.githubusercontent.com/10683896/197723388-82778384-08ea-4f9b-8bf7-5e51250b2a04.png)