### PR TITLE
Feature/improve error handling and logging

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -519,7 +519,11 @@ namespace WorkItemImport
             }
             catch (AggregateException ex)
             {
-                Logger.Log(ex, "Work Item " + wi.Id + " failed to save.");
+                foreach (Exception ex2 in ex.InnerExceptions)
+                {
+                    Logger.Log(LogLevel.Error, ex2.Message);
+                }
+                Logger.Log(LogLevel.Error, "Work Item " + wi.Id + " failed to save.");
             }
         }
 

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -80,7 +80,14 @@ namespace WorkItemImport
                     }
                     return false;
                 }
-
+                catch (AggregateException ex)
+                {
+                    foreach (Exception ex2 in ex.InnerExceptions)
+                    {
+                        Logger.Log(LogLevel.Error, ex2.Message);
+                    }
+                    return false;
+                }
                 catch (Exception ex)
                 {
 


### PR DESCRIPTION
I'm seeing an AggregateException causing the following log message during import:
[E][20:43:17] One or more errors occurred.

It can be more helpful to unpack the AggregateException and log it's innerexception. What are your thoughts on logging the full stacktrace here? In my experience the VisualStudio framework stacktraces do not provide much more value than the message, and the stacktrace clutters the log. Could add them as debug log level maybe.

Please see this PR as suggestion.