### PR TITLE
Ability to create work item and changes in the past

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -65,9 +65,9 @@ namespace WorkItemImport
             return _witClientUtils.GetWorkItem(wiId);
         }
 
-        public WorkItem CreateWorkItem(string type)
+        public WorkItem CreateWorkItem(string type, DateTime createdDate, string createdBy)
         {
-            return _witClientUtils.CreateWorkItem(type);
+            return _witClientUtils.CreateWorkItem(type, createdDate, createdBy);
         }
 
         public bool ImportRevision(WiRevision rev, WorkItem wi)

--- a/src/WorkItemMigrator/WorkItemImport/ImportCommandLine.cs
+++ b/src/WorkItemMigrator/WorkItemImport/ImportCommandLine.cs
@@ -122,7 +122,7 @@ namespace WorkItemImport
                         if (executionItem.WiId > 0)
                             wi = agent.GetWorkItem(executionItem.WiId);
                         else
-                            wi = agent.CreateWorkItem(executionItem.WiType);
+                            wi = agent.CreateWorkItem(executionItem.WiType, executionItem.Revision.Time, executionItem.Revision.Author);
 
                         Logger.Log(LogLevel.Info, $"Processing {importedItems + 1}/{revisionCount} - wi '{(wi.Id > 0 ? wi.Id.ToString() : "Initial revision")}', jira '{executionItem.OriginId}, rev {executionItem.Revision.Index}'.");
 

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/IWitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/IWitClientWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
@@ -8,7 +9,7 @@ namespace WorkItemImport
 {
     public interface IWitClientWrapper
     {
-        WorkItem CreateWorkItem(string wiType);
+        WorkItem CreateWorkItem(string wiType, DateTime createdDate = default, string createdBy = "");
         WorkItem GetWorkItem(int wiId);
         WorkItem UpdateWorkItem(JsonPatchDocument patchDocument, int workItemId);
         TeamProject GetProject(string projectId);

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -642,6 +642,9 @@ namespace WorkItemImport
             Logger.Log(LogLevel.Info, "");
 
             wi.Relations = result.Relations;
+
+            // While updating the work item, the changed date can be increased, hence we take it over
+            wi.Fields[WiFieldReference.ChangedDate] = result.Fields[WiFieldReference.ChangedDate];
         }
 
         private void RemoveSingleAttachmentFromWorkItemAndSave(WiAttachment att, WorkItem wi, DateTime changedDate = default, string changedBy = default)

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -474,12 +474,16 @@ namespace WorkItemImport
             {
                 if (attachment.Change == ReferenceChangeType.Added)
                 {
-                   AddSingleAttachmentToWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(5), rev.Author);
+                    AddSingleAttachmentToWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(5), rev.Author);
                 }
                 else if (attachment.Change == ReferenceChangeType.Removed)
                 {
                     RemoveSingleAttachmentFromWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(5), rev.Author);
                 }
+
+                // The work item ChangeDate is altered when saving the attachment, make sure the Revision time does too.
+                // Otherwise it will not be an increased ChangedDate and we'll get an exception
+                rev.Time = (DateTime)wi.Fields[WiFieldReference.ChangedDate];
             }
         }
 

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -209,8 +209,9 @@ namespace WorkItemImport
                 }
                 else
                 {
-                    rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ChangedDate, Value = rev.Time.AddMilliseconds(1).ToString("o") });
-                    wi.Fields[WiFieldReference.ChangedDate] = rev.Time.AddMilliseconds(1);
+                    // Seen while testing: DevOps can add a few milliseconds to work item createdDate, hence adding more here to the revision time
+                    rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ChangedDate, Value = rev.Time.AddMilliseconds(5).ToString("o") });
+                    wi.Fields[WiFieldReference.ChangedDate] = rev.Time.AddMilliseconds(5);
                 }
             }
 
@@ -473,11 +474,11 @@ namespace WorkItemImport
             {
                 if (attachment.Change == ReferenceChangeType.Added)
                 {
-                   AddSingleAttachmentToWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(1), rev.Author);
+                   AddSingleAttachmentToWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(5), rev.Author);
                 }
                 else if (attachment.Change == ReferenceChangeType.Removed)
                 {
-                    RemoveSingleAttachmentFromWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(1), rev.Author);
+                    RemoveSingleAttachmentFromWorkItemAndSave(attachment, wi, rev.Time.AddMilliseconds(5), rev.Author);
                 }
             }
         }

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -25,9 +25,9 @@ namespace WorkItemImport
 
         public delegate V IsAttachmentMigratedDelegate<in T, U, out V>(T input, out U output);
 
-        public WorkItem CreateWorkItem(string type)
+        public WorkItem CreateWorkItem(string type, DateTime createdDate = default, string createdBy = "")
         {
-            return _witClientWrapper.CreateWorkItem(type);
+            return _witClientWrapper.CreateWorkItem(type, createdDate, createdBy);
         }
 
         public bool IsDuplicateWorkItemLink(IEnumerable<WorkItemRelation> links, WorkItemRelation relatedLink)

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
@@ -57,6 +57,13 @@ namespace WorkItemImport
                     Path = "/fields/" + WiFieldReference.CreatedDate,
                     Value = createdDate
                 });
+
+                patchDoc.Add(new JsonPatchOperation()
+                {
+                    Operation = Operation.Add,
+                    Path = "/fields/" + WiFieldReference.ChangedDate,
+                    Value = createdDate
+                });
             }
 
             if (createdBy != default)
@@ -65,6 +72,13 @@ namespace WorkItemImport
                 {
                     Operation = Operation.Add,
                     Path = "/fields/" + WiFieldReference.CreatedBy,
+                    Value = createdBy
+                });
+
+                patchDoc.Add(new JsonPatchOperation()
+                {
+                    Operation = Operation.Add,
+                    Path = "/fields/" + WiFieldReference.ChangedBy,
                     Value = createdBy
                 });
             }

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
@@ -37,7 +37,7 @@ namespace WorkItemImport
             DefaultWorkItemType = DefaultWorkItemTypeCategory.DefaultWorkItemType;
         }
 
-        public WorkItem CreateWorkItem(string wiType)
+        public WorkItem CreateWorkItem(string wiType, DateTime createdDate = default, string createdBy = "")
         {
             JsonPatchDocument patchDoc = new JsonPatchDocument
             {
@@ -48,6 +48,26 @@ namespace WorkItemImport
                     Value = "[Placeholder Name]"
                 }
             };
+
+            if (createdDate != default)
+            {
+                patchDoc.Add(new JsonPatchOperation()
+                {
+                    Operation = Operation.Add,
+                    Path = "/fields/" + WiFieldReference.CreatedDate,
+                    Value = createdDate
+                });
+            }
+
+            if (createdBy != default)
+            {
+                patchDoc.Add(new JsonPatchOperation()
+                {
+                    Operation = Operation.Add,
+                    Path = "/fields/" + WiFieldReference.CreatedBy,
+                    Value = createdBy
+                });
+            }
 
             WorkItem wiOut;
             try

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientWrapper.cs
@@ -72,7 +72,7 @@ namespace WorkItemImport
             WorkItem wiOut;
             try
             {
-                wiOut = WitClient.CreateWorkItemAsync(document:patchDoc, project:TeamProject.Name, type:wiType, bypassRules:false, expand:WorkItemExpand.All).Result;
+                wiOut = WitClient.CreateWorkItemAsync(document:patchDoc, project:TeamProject.Name, type:wiType, bypassRules:true, expand:WorkItemExpand.All).Result;
             } catch (Exception e)
             {
                 Logger.Log(LogLevel.Error, "Error when creating new Work item: " + e.Message);

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -32,12 +32,16 @@ namespace Migration.Wi_Import.Tests
 
             }
 
-            public WorkItem CreateWorkItem(string wiType)
+            public WorkItem CreateWorkItem(string wiType, DateTime createdDate = default, string createdBy = "")
             {
                 WorkItem workItem = new WorkItem();
                 workItem.Id = _wiIdCounter;
                 workItem.Url = $"https://example/workItems/{_wiIdCounter}";
                 workItem.Fields[WiFieldReference.WorkItemType] = wiType;
+                if(createdDate != default)
+                    workItem.Fields[WiFieldReference.CreatedDate] = createdDate;
+                if (createdBy != default)
+                    workItem.Fields[WiFieldReference.CreatedBy] = createdBy;
                 workItem.Relations = new List<WorkItemRelation>();
                 _wiCache[_wiIdCounter] = (workItem);
                 _wiIdCounter++;


### PR DESCRIPTION
I created this PR that hopefully can be merged into the tool.
It resolves the by-design issue that was pointed out in #614.

Things that I did:
1. Changed the bypassRule to true, otherwise Azure DevOps won't allow you to alter the Created and Changed fields.
2. Another thing to keep in mind is that the ChangedDate always increases, otherwise you get this exception: `VS402625: Dates must be increasing with each revision.` This happened to me when updating the work item but also when adding the attachments, so I added some logic in there which counters this.

I did test my changes on a customer case were we are doing a migration, and today's run was without errors after my last fix to the attachment ChangedDate. The migration contains roughly 400 issues for the first phase.

When executing it now should look like this instead of the date of execution:
![image](https://user-images.githubusercontent.com/41574930/203109330-05ea1e05-8420-493b-a6cb-ecda0414e022.png)

Can you guys review, as I tried to keep it as close as the code that was already there. Let me know if there's something unclear.