### PR TITLE
Add ClosedDate to closing revision if not provided

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -245,8 +245,14 @@ namespace WorkItemImport
                     rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ActivatedBy, Value = null });
                 }
 
-                if (revState.Equals("Done", StringComparison.InvariantCultureIgnoreCase) && !rev.Fields.HasAnyByRefName(WiFieldReference.ClosedBy))
-                    rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ClosedBy, Value = rev.Author });
+                if (revState.Equals("Done", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if (!rev.Fields.HasAnyByRefName(WiFieldReference.ClosedDate))
+                        rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ClosedDate, Value = rev.Time });
+
+                    if (!rev.Fields.HasAnyByRefName(WiFieldReference.ClosedBy))
+                        rev.Fields.Add(new WiField() { ReferenceName = WiFieldReference.ClosedBy, Value = rev.Author });
+                }
             }
         }
 


### PR DESCRIPTION
After importing issues into my DevOps server, it complained that closed work items had an empty 'Closed Date' field:
![image](https://user-images.githubusercontent.com/18261782/205878330-4261fad2-8022-4bae-9116-d29fababea1a.png)

This change fixes that issue.

Closely related to PR #628 which takes care that the revisions are correctly dated in the past.

