### PR TITLE
Composite field mapper

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -100,6 +100,7 @@ Currently the tool has a rather naive implementation for mapping certain constru
 |MapArray|Maps an array by replacing comma with semi-colon|
 |MapRemainingWork|Maps and converts a Jira time to hours|
 |MapRendered|Maps field to rendered html format value|
+|MapFieldsComposite|Maps multiple fields and concatenates the field values based on a user-defined pattern. In the `source` field, you must specify a pattern where any `${...}` tokens will indicate a field substitution. For example, use `${state}` to include the issue state in the mapped value.|
 |(default)|Simply copies soure to target|
 
 ## Example configuration
@@ -185,7 +186,7 @@ Currently the tool has a rather naive implementation for mapping certain constru
       {
         "source": "description",
         "target": "System.Description",
-		"mapper":"MapRendered"
+	"mapper":"MapRendered"
       },
       {
         "source": "priority",
@@ -249,7 +250,12 @@ Currently the tool has a rather naive implementation for mapping certain constru
       {
         "source": "comment",
         "target": "System.History",
-		"mapper":"MapRendered"
+	"mapper":"MapRendered"
+      },
+      {
+      	"source": "${customfield_a}-${customfield_b}",
+        "target": "Custom.ConcatenatedAB",
+	"mapper": "MapFieldsComposite"
       },
       {
         "source": "status",

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,7 @@
 ## FAQ - Frequently Asked Questions
-1. Convert Jira formatted descriptions and comments on migration
+
+### 1. Convert Jira formatted descriptions and comments on migration
+
 - With our latest release (2.3.1) we have introduced a new mapper called "MapRendered" that should be used when mapping fields to get the Html rendered value from Jira. 
 
 Example:
@@ -9,11 +11,13 @@ Example:
     `"mapper":"MapRendered"`
 `}`
 
-2. Why I am getting Unauthorized exception when running export?
+### 2. Why I am getting Unauthorized exception when running export?
+
 -   It might be that you are using your email as a username, try to use your username instead of an email address.
 - using Jira Cloud   - it might be that you need to to use the API token as a password.
 
-3. How to map custom field by name?
+### 3. How to map custom field by name?
+
  - To map a custom field by name we have to add a mapping in the configuration file.
 
  Example: 
@@ -23,7 +27,8 @@ Example:
     "target": "Microsoft.VSTS.TCM.ReproSteps"
 }`
 
-4. How to migrate custom fields having dropdownlists?
+### 4. How to migrate custom fields having dropdownlists?
+
 - To map a custom field which is an dropdown list you can use MapArray mapper to get in a better way.
 Also take a look at the other possible [Mappers](config.md#mappers) to use. 
 
@@ -37,7 +42,8 @@ Example:
     }
 `
 
-5. How to migrate correct user from Jira to Azure DevOps and assign to the new work items ?
+### 5. How to migrate correct user from Jira to Azure DevOps and assign to the new work items?
+
 - User mapping  differes between Jira Cloud and Jira Server. To migrate users and assign the new work items in Azure DevOps to the same user as the original task had in Jira, we need to add a text file in the root that would look something like this:
 
  - When using Jira Cloud then firstly make sure in the config the '"using-jira-cloud": true' is set. The mapping file the should have accountId/email value pairs. To use email value pairs the users email should be set to public in the user profile in Jira Cloud
@@ -59,3 +65,24 @@ Example:
         Jira.User2@some.domain=AzureDevOps.User2@some.domain
         Jira.User3@some.domain=AzureDevOps.User3@some.domain
 
+### 6. How to concatenate/combine fields?
+
+It is possible to concatenate fields and specify a custom pattern with the **FieldsComposite** mapper. You will need to include the following mapper in your config file:
+
+```
+{
+  "source": "${field1}-${field2}",
+  "target": "Custom.TargetField",
+  "mapper": "MapFieldsComposite"
+}
+```
+
+Here is another example for adding the issue title to the description:
+
+```
+{
+  "source": "${summary}<br/>${description}",
+  "target": "System.Description",
+  "mapper": "MapFieldsComposite"
+}
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ### 1. Convert Jira formatted descriptions and comments on migration
 
-- With our latest release (2.3.1) we have introduced a new mapper called "MapRendered" that should be used when mapping fields to get the Html rendered value from Jira. 
+- With our latest release (2.3.1) we have introduced a new mapper called "MapRendered" that should be used when mapping fields to get the Html rendered value from Jira.
 
 Example:
 `{`
@@ -13,26 +13,26 @@ Example:
 
 ### 2. Why I am getting Unauthorized exception when running export?
 
--   It might be that you are using your email as a username, try to use your username instead of an email address.
+- It might be that you are using your email as a username, try to use your username instead of an email address.
 - using Jira Cloud   - it might be that you need to to use the API token as a password.
 
 ### 3. How to map custom field by name?
 
- - To map a custom field by name we have to add a mapping in the configuration file.
+- To map a custom field by name we have to add a mapping in the configuration file.
 
- Example: 
+ Example:
 `{
     "source": "CustomFieldName",
     "source-type": "name",
     "target": "Microsoft.VSTS.TCM.ReproSteps"
 }`
 
-### 4. How to migrate custom fields having dropdownlists?
+### 4. How to migrate custom fields having dropdown lists?
 
 - To map a custom field which is an dropdown list you can use MapArray mapper to get in a better way.
 Also take a look at the other possible [Mappers](config.md#mappers) to use. 
 
-Example: 
+Example:
 ` {
         "source": "UserPicker",
         "source-type": "name",
@@ -44,10 +44,9 @@ Example:
 
 ### 5. How to migrate correct user from Jira to Azure DevOps and assign to the new work items?
 
-- User mapping  differes between Jira Cloud and Jira Server. To migrate users and assign the new work items in Azure DevOps to the same user as the original task had in Jira, we need to add a text file in the root that would look something like this:
+- User mapping differs between Jira Cloud and Jira Server. To migrate users and assign the new work items in Azure DevOps to the same user as the original task had in Jira, we need to add a text file in the root that would look something like this:
 
- - When using Jira Cloud then firstly make sure in the config the '"using-jira-cloud": true' is set. The mapping file the should have accountId/email value pairs. To use email value pairs the users email should be set to public in the user profile in Jira Cloud
- otherwise the tool cant get the email and will use accountId instead for mapping.
+- When using Jira Cloud then firstly make sure in the config the '"using-jira-cloud": true' is set. The mapping file the should have accountId/email value pairs. To use email value pairs the users email should be set to public in the user profile in Jira Cloud. Otherwise the tool cannot get the email and will use accountId instead for mapping.
 
         Jira.User1@some.domain=AzureDevOps.User1@some.domain
         Jira.User2@some.domain=AzureDevOps.User2@some.domain
@@ -59,7 +58,7 @@ Example:
         JiraAccountId2=AzureDevOps.User2@some.domain
         JiraAccountId3=AzureDevOps.User3@some.domain
 
- - When using Jira Server then firstly make sure in the config the ' "using-jira-cloud": false' is set. The mapping should look like the example below:
+- When using Jira Server then firstly make sure in the config the ' "using-jira-cloud": false' is set. The mapping should look like the example below:
 
         Jira.User1@some.domain=AzureDevOps.User1@some.domain
         Jira.User2@some.domain=AzureDevOps.User2@some.domain

--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -110,6 +110,9 @@ namespace JiraExport
                             case "MapRendered":
                                 value = r => FieldMapperUtils.MapRenderedValue(r, item.Source, isCustomField, _jiraProvider.GetCustomId(item.Source), _config);
                                 break;
+                            case "MapFieldsComposite":
+                                value = r => FieldMapperUtils.MapFieldsComposite(r, item.Source, isCustomField, _config);
+                                break;
                             default:
                                 value = IfChanged<string>(item.Source, isCustomField);
                                 break;

--- a/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
+++ b/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
@@ -125,7 +125,7 @@ namespace JiraExport
             string mapped = sourceField;
 
             // Match source fields, pattern: "${...}"
-            var matches = Regex.Matches(sourceField, "\\$\\{.+?\\}");
+            var matches = Regex.Matches(sourceField, "\\$\\{.+?\\}", RegexOptions.None, TimeSpan.FromMilliseconds(100));
             foreach (var match in matches)
             {
                 string matchStripped = match.ToString().Replace("${", "").Replace("}", "");

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
@@ -412,6 +412,75 @@ namespace Migration.Jira_Export.Tests.RevisionUtils
             Assert.Throws<ArgumentNullException>(() => { FieldMapperUtils.MapRenderedValue(null, null, false, null, null); });
         }
 
+        [Test]
+        public void When_calling_map_fields_composite_with_valid_input_Then_expected_output_is_returned()
+        {
+            var sourceField = "${summary}---${description}";
+            var configJson = _fixture.Create<ConfigJson>();
+            var summary = "My Summary";
+            var description = "My Description";
 
+            var expectedOutput = summary + "---" + description;
+
+            configJson.TypeMap.Types = new List<Common.Config.Type>() { new Common.Config.Type() { Source = "Story", Target = "Story" } };
+            configJson.FieldMap.Fields = new List<Common.Config.Field>()
+            {
+                new Common.Config.Field()
+                {
+                    Source = sourceField,
+                    Target = "System.Description",
+                    Mapper = "MapFieldsComposite"
+                }
+            };
+
+            var jiraRevision = MockRevisionWithParentItem("issue_key", summary);
+            jiraRevision.Fields.Add("description", description);
+
+            var actualOutput = FieldMapperUtils.MapFieldsComposite(jiraRevision, sourceField, false, configJson);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualOutput.Item1, Is.True);
+                Assert.That(actualOutput.Item2, Is.EqualTo(expectedOutput));
+            });
+        }
+
+        [Test]
+        public void When_calling_map_fields_composite_with_invalid_input_Then_expected_false_and_null_is_returned()
+        {
+            var sourceField = "${summary}---${description}";
+            var configJson = _fixture.Create<ConfigJson>();
+            var summary = "My Summary";
+            var description = "My Description";
+
+            var expectedOutput = summary + "---" + description;
+
+            configJson.TypeMap.Types = new List<Common.Config.Type>() { new Common.Config.Type() { Source = "Story", Target = "Story" } };
+            configJson.FieldMap.Fields = new List<Common.Config.Field>()
+            {
+                new Common.Config.Field()
+                {
+                    Source = sourceField,
+                    Target = "System.Description",
+                    Mapper = "MapFieldsComposite"
+                }
+            };
+
+            var jiraRevision = MockRevisionWithParentItem("issue_key", summary);
+
+            var actualOutput = FieldMapperUtils.MapFieldsComposite(jiraRevision, sourceField, false, configJson);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualOutput.Item1, Is.False);
+                Assert.That(actualOutput.Item2, Is.EqualTo(null));
+            });
+        }
+
+        [Test]
+        public void When_calling_map_fields_composite_with_null_arguments_Then_and_exception_is_thrown()
+        {
+            Assert.Throws<ArgumentNullException>(() => { FieldMapperUtils.MapFieldsComposite(null, null, false, null); });
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new mapper that can concatenate multiple revision fields into one value.

Here is an example configuration that shows how to use the new mapper:

```json
{
  "source": "${summary}---${description}",
  "target": "System.Description",
  "mapper": "MapFieldsComposite"
}
```

This mapping will concatenate the values of `summary` and `description` together according to the pattern specified in `source`, and map the resulting value to `System.Description`