### PR TITLE
Handling for 100 attachment-limit

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -474,7 +474,14 @@ namespace WorkItemImport
             {
                 if (attachment.Change == ReferenceChangeType.Added)
                 {
-                    AddSingleAttachmentToWorkItemAndSave(attachment, wi, attachmentUpdatedDate, rev.Author);
+                    try
+                    {
+                        AddSingleAttachmentToWorkItemAndSave(attachment, wi, attachmentUpdatedDate, rev.Author);
+                    }
+                    catch (AggregateException)
+                    {
+                        Logger.Log(LogLevel.Warning, $"'{rev}' - tried to add an attachment, but hit the workitem attachment limit (cannot add more than 100 attachments. Skipping attachment: {attachment.FileName}");
+                    }
                 }
                 else if (attachment.Change == ReferenceChangeType.Removed)
                 {
@@ -609,7 +616,7 @@ namespace WorkItemImport
         {
             // Upload attachment
             AttachmentReference attachment = _witClientWrapper.CreateAttachment(att);
-            Logger.Log(LogLevel.Info, "Attachment created");
+            Logger.Log(LogLevel.Info, "Adding single attachment");
             Logger.Log(LogLevel.Info, $"ID: {attachment.Id}");
             Logger.Log(LogLevel.Info, $"URL: '{attachment.Url}'");
             Logger.Log(LogLevel.Info, "");


### PR DESCRIPTION
Fixes https://github.com/solidify/jira-azuredevops-migrator/issues/626

Example log:

```
[I][19:24:13] Adding single attachment
[I][19:24:13] ID: d85549d7-aa18-43fc-814d-cc51c48c1d67
[I][19:24:13] URL: 'https://dev.azure.com/solidifydemo/_apis/wit/attachments/d85549d7-aa18-43fc-814d-cc51c48c1d67?fileName=image-20230215-180027.png'
[I][19:24:13] 
[W][19:24:14] ''AGILEDEMO-24', rev 0' - tried to add an attachment, but hit the workitem attachment limit (cannot add more than 100 attachments. Skipping attachment: image-20230215-180027.png
[I][19:24:16] Processing 2/2 - wi '50599', jira 'AGILEDEMO-24, rev 1'.
[W][19:24:16] Attachment '[Added] 10067/image-20230215-180027.png' referenced in text but is missing from work item AGILEDEMO-24/50599.
```