### PR TITLE
Error message for large attachments

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -478,9 +478,25 @@ namespace WorkItemImport
                     {
                         AddSingleAttachmentToWorkItemAndSave(attachment, wi, attachmentUpdatedDate, rev.Author);
                     }
-                    catch (AggregateException)
+                    catch (AggregateException e)
                     {
-                        Logger.Log(LogLevel.Warning, $"'{rev}' - tried to add an attachment, but hit the workitem attachment limit (cannot add more than 100 attachments. Skipping attachment: {attachment.FileName}");
+                        if(e.InnerException.Message.Contains("TF237082"))
+                        {
+                            Logger.Log(LogLevel.Warning, $"'{rev}' - tried to add an attachment, But the attachment exceeds " +
+                                $"the supported file upload size. Skipping attachment: {attachment.FileName}. See full error " +
+                                $"message below.\n{e.InnerException.Message}");
+                        }
+                        else if(e.InnerException.Message.Contains("VS403313"))
+                        {
+                            Logger.Log(LogLevel.Warning, $"'{rev}' - tried to add an attachment, but hit the workitem attachment " +
+                                $"limit (cannot add more than 100 attachments. Skipping attachment: {attachment.FileName}");
+                        }
+                        else
+                        {
+                            Logger.Log(LogLevel.Warning, $"'{rev}' - tried to add an attachment, but encountered an unhandled " +
+                                $"exception. Skipping attachment: {attachment.FileName}. See full error " +
+                                $"message below.\n{e.InnerException.Message}");
+                        }
                     }
                 }
                 else if (attachment.Change == ReferenceChangeType.Removed)


### PR DESCRIPTION
Fixes https://github.com/solidify/jira-azuredevops-migrator/issues/638

Adds error handling for large attachments

New output:

```
[I][12:15:08] Processing 3/3 - wi '50652', jira 'AGILEDEMO-25, rev 0'.
[W][12:15:14] ''AGILEDEMO-25', rev 0' - tried to add an attachment, But the attachment exceeds the supported file upload size. Skipping attachment: large_attachment-1.txt. See full error message below.
TF237082: The file you are trying to upload exceeds the supported file upload size (60.000 MB(s)). Instead of uploading the file, add the file to version control or to the team project web site, and then link the file to the work item.
```