### PR TITLE
Bugfix/Exporting a revision with deleted resolution throws a NullReferenceException

### DIFF
--- a/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
+++ b/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
@@ -65,6 +65,10 @@ namespace JiraExport
                       item.Source == itemSource && (!string.IsNullOrWhiteSpace(item.NotFor) && !item.NotFor.Contains(targetWit))) &&
                       item.Mapping?.Values != null)
                 {
+                    if (value == null)
+                    {
+                        return (true, null);
+                    }
                     var mappedValue = (from s in item.Mapping.Values where s.Source == value.ToString() select s.Target).FirstOrDefault();
                     if (string.IsNullOrEmpty(mappedValue))
                     {

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
@@ -244,6 +244,44 @@ namespace Migration.Jira_Export.Tests.RevisionUtils
         }
 
         [Test]
+        public void When_calling_map_value_with_valid_args_and_null_sourcevalue_Then_expected_output_is_returned()
+        {
+
+            var configJson = _fixture.Create<ConfigJson>();
+
+            configJson.TypeMap.Types = new List<Common.Config.Type>() { new Common.Config.Type() { Source = "Story", Target = "Story" } };
+            configJson.FieldMap.Fields = new List<Common.Config.Field>()
+            {
+                new Common.Config.Field()
+                    {
+                        Source = "resolution", Target = "System.Reason",
+                        Mapping = new Common.Config.Mapping
+                        {
+                            Values = new List<Common.Config.Value>
+                            {
+                                new Common.Config.Value
+                            {
+                                Source = "Fixed", Target = "Resolved"
+                                }
+                            }
+                            }
+                        }
+                    };
+            
+            var jiraRevision = MockRevisionWithParentItem("issue_key", "My Summary");
+            // Ensure a null value is added to the revision
+            jiraRevision.Fields.Add("resolution", null);
+
+            var actualOutput = FieldMapperUtils.MapValue(jiraRevision, "resolution", "System.Reason", configJson);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualOutput.Item1, Is.True);
+                Assert.That(actualOutput.Item2, Is.Null);
+            });
+        }
+
+        [Test]
         public void When_calling_map_value_with_missing_args_Then_false_and_null_is_returned()
         {
 


### PR DESCRIPTION
Fix for #270 

The TryGetValue only checks if the value is there, not if it contains a value or a null. The code to return the value failed in handling the null value. The null value is important here to empty the target field to correctly reflect the source.