### PR TITLE
Resolved inability to use mapping on custom fields on initial revision.

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -39,17 +39,18 @@ namespace JiraExport
             var remoteIssue = jiraItem.RemoteIssue;
             Dictionary<string, object> fieldsTemp = ExtractFields(issueKey, remoteIssue, jiraProvider);
             
-            // Add copies of the fields using the CustomFieldName.
+            // Add CustomFieldName fields, copy over all non-custom fields.
             // These get removed as we loop over the changeLog, so we're left with the original Jira values by the time we reach firstRevision.
             Dictionary<string, object> fields = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
             foreach (var field in fieldsTemp)
             {
-                //We keep the originals keys also, as for some reason the iteration path isn't created without them, and I presume other things probably break too.
-                fields[field.Key] = field.Value;
                 var key = GetCustomFieldName(field.Key, jiraProvider);
                 if (!String.IsNullOrEmpty(key))
                 {
                     fields[key] = field.Value;
+                } else
+                {
+                    fields[field.Key] = field.Value;
                 }
             }
 


### PR DESCRIPTION
*Add copy of CustomeField_XXX using real jira field name in order that mapping values works on initial revision.*

We ran into an issue where we were unable to output values that used the `mapping` feature with custom Jira fields.

When debugging it turned out that the fields in the initial revision used the internal name `CustomField_12345` and not the visible name.
I also spotted that switching the mapping on and off caused the fields to turn up at different revisions in the output.

This indicated to me that the initial parsing of the Jira was probably treating the initial revision differently from all the others.

This change fixes this issue.

I haven't added a test, can you advise how best I can add a test which uses custom fields and mapping?
It looked like these were being tested in very different ways and I wasn't sure the best way/place to proceed.