### PR TITLE
Fix incorrect formatting for jira image URLs in comments

### DIFF
--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -565,10 +565,12 @@ namespace WorkItemImport
                 throw new ArgumentException(nameof(rev));
             }
 
-            foreach (var att in wiItem.Revisions.SelectMany(r => r.Attachments.Where(a => a.Change == ReferenceChangeType.Added)))
+            var filteredRelations = wiItem.Revisions.SelectMany(r => r.Attachments.Where(a => a.Change == ReferenceChangeType.Added));
+
+            foreach (var att in filteredRelations)
             {
                 var fileName = att.FilePath.Split('\\')?.Last() ?? string.Empty;
-                var encodedFileName = HttpUtility.UrlEncode(fileName);
+                var encodedFileName = EncodeFileNameUsingJiraStandard(fileName);
                 if (textField.Contains(fileName) || textField.IndexOf(encodedFileName, StringComparison.OrdinalIgnoreCase) >= 0 || textField.Contains("_thumb_" + att.AttOriginId))
                 {
                     var tfsAtt = IdentifyAttachment(att, wi, isAttachmentMigratedDelegate);
@@ -595,6 +597,15 @@ namespace WorkItemImport
                 wi.Fields[WiFieldReference.ChangedBy] = rev.Author;
             }
         }
+
+        public string EncodeFileNameUsingJiraStandard(string fileName)
+        {
+            string fileNameEncoded = HttpUtility.UrlEncode(fileName);
+            fileNameEncoded = fileNameEncoded.Replace("(", "%28");
+            fileNameEncoded = fileNameEncoded.Replace(")", "%29");
+            return fileNameEncoded;
+        }
+
 
         private void CorrectClosedByAndClosedDate(WiRevision rev, WorkItem wi)
         {

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -569,9 +569,15 @@ namespace WorkItemImport
 
             foreach (var att in filteredRelations)
             {
-                var fileName = att.FilePath.Split('\\')?.Last() ?? string.Empty;
-                var encodedFileName = EncodeFileNameUsingJiraStandard(fileName);
-                if (textField.Contains(fileName) || textField.IndexOf(encodedFileName, StringComparison.OrdinalIgnoreCase) >= 0 || textField.Contains("_thumb_" + att.AttOriginId))
+                string fileName = att.FilePath.Split('\\')?.Last() ?? string.Empty;
+                string encodedFileName = EncodeFileNameUsingJiraStandard(fileName);
+                string restApiUrlOption = "/rest/api/3/attachment/content/" + att.AttOriginId;
+                if (
+                    textField.Contains(fileName)
+                    || textField.IndexOf(encodedFileName, StringComparison.OrdinalIgnoreCase) >= 0
+                    || textField.Contains("_thumb_" + att.AttOriginId)
+                    || textField.Contains(restApiUrlOption)
+                )
                 {
                     var tfsAtt = IdentifyAttachment(att, wi, isAttachmentMigratedDelegate);
 

--- a/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Wi-Import.Tests/WitClient/WitClientUtilsTests.cs
@@ -974,5 +974,37 @@ namespace Migration.Wi_Import.Tests
                 Assert.That(updatedWI.Fields[WiFieldReference.Priority], Is.EqualTo(createdWI.Fields[WiFieldReference.Priority]));
             });
         }
+
+        [Test]
+        public void EncodeFileNameUsingJiraStandard_encodes_file_name_with_special_characters()
+        {
+            // Arrange
+            MockedWitClientWrapper witClientWrapper = new MockedWitClientWrapper();
+            WitClientUtils wiUtils = new WitClientUtils(witClientWrapper);
+            string fileName = "My File (Special).txt";
+            string expectedEncodedFileName = "My+File+%28Special%29.txt";
+
+            // Act
+            string encodedFileName = wiUtils.EncodeFileNameUsingJiraStandard(fileName);
+
+            // Assert
+            Assert.AreEqual(expectedEncodedFileName, encodedFileName);
+        }
+
+        [Test]
+        public void EncodeFileNameUsingJiraStandard_encodes_file_name_with_no_special_characters()
+        {
+            // Arrange
+            MockedWitClientWrapper witClientWrapper = new MockedWitClientWrapper();
+            WitClientUtils wiUtils = new WitClientUtils(witClientWrapper);
+            string fileName = "MyFile.txt";
+            string expectedEncodedFileName = "MyFile.txt";
+
+            // Act
+            string encodedFileName = wiUtils.EncodeFileNameUsingJiraStandard(fileName);
+
+            // Assert
+            Assert.AreEqual(expectedEncodedFileName, encodedFileName);
+        }
     }
 }


### PR DESCRIPTION
Related to https://github.com/solidify/jira-azuredevops-migrator/issues/780
Integration tests: https://dev.azure.com/solidify/Internal/_build/results?buildId=12695&view=results