### PR TITLE
Ensure jira revisions are ordered by Index before saving the file

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -45,9 +45,10 @@ namespace JiraExport
                 if (type != null)
                 {
                     var revisions = issue.Revisions.Select(r => MapRevision(r)).ToList();
+                    var revisionsSorted = GetSortedRevisions(revisions); // In some cases we have noticed that the issues appear out of order
                     wiItem.OriginId = issue.Key;
                     wiItem.Type = type;
-                    wiItem.Revisions = revisions;
+                    wiItem.Revisions = revisionsSorted;
                 }
                 else
                 {
@@ -56,6 +57,16 @@ namespace JiraExport
                 }
             }
             return wiItem;
+        }
+
+        internal List<WiRevision> GetSortedRevisions(List<WiRevision> revisions)
+        {
+            List<WiRevision> revisionsSorted = revisions.OrderBy(r => r.Time).ToList();
+            for (int i = 0; i < revisionsSorted.Count; i++)
+            {
+                revisionsSorted[i].Index = i;
+            }
+            return revisionsSorted;
         }
 
         internal Dictionary<string, FieldMapping<JiraRevision>> InitializeFieldMappings()

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
@@ -260,9 +260,9 @@ namespace Migration.Jira_Export.Tests
             Assert.AreEqual(sortedRevisions[0], unsortedRevisions[2]);
             Assert.AreEqual(sortedRevisions[1], unsortedRevisions[0]);
             Assert.AreEqual(sortedRevisions[2], unsortedRevisions[1]);
-            Assert.AreEqual(sortedRevisions[0].Index, 0);
-            Assert.AreEqual(sortedRevisions[1].Index, 1);
-            Assert.AreEqual(sortedRevisions[2].Index, 2);
+            Assert.AreEqual(0, sortedRevisions[0].Index);
+            Assert.AreEqual(1, sortedRevisions[1].Index);
+            Assert.AreEqual(2, sortedRevisions[2].Index);
         }
 
         private JiraSettings createJiraSettings()

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
@@ -13,6 +13,7 @@ using NSubstitute;
 using System.Diagnostics.CodeAnalysis;
 using Type = Migration.Common.Config.Type;
 using System.Linq;
+using System;
 
 namespace Migration.Jira_Export.Tests
 {
@@ -229,6 +230,39 @@ namespace Migration.Jira_Export.Tests
             var actual = sut.InitializeFieldMappings();
 
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void When_calling_get_sorted_revisions_Then_the_expected_result_is_returned()
+        {
+            List<WiRevision> unsortedRevisions = new List<WiRevision>();
+
+            WiRevision rev0 = new WiRevision();
+            rev0.Index = 0;
+            rev0.Time = DateTime.Now;
+
+            WiRevision revPlus1 = new WiRevision();
+            revPlus1.Index = 1;
+            revPlus1.Time = DateTime.Now.AddDays(1);
+
+            WiRevision revMinus1 = new WiRevision();
+            revMinus1.Index = 2;
+            revMinus1.Time = DateTime.Now.AddDays(-1);
+
+            unsortedRevisions.Add(rev0);
+            unsortedRevisions.Add(revPlus1);
+            unsortedRevisions.Add(revMinus1);
+
+            JiraMapper sut = createJiraMapper();
+
+            var sortedRevisions = sut.GetSortedRevisions(unsortedRevisions);
+
+            Assert.AreEqual(sortedRevisions[0], unsortedRevisions[2]);
+            Assert.AreEqual(sortedRevisions[1], unsortedRevisions[0]);
+            Assert.AreEqual(sortedRevisions[2], unsortedRevisions[1]);
+            Assert.AreEqual(sortedRevisions[0].Index, 0);
+            Assert.AreEqual(sortedRevisions[1].Index, 1);
+            Assert.AreEqual(sortedRevisions[2].Index, 2);
         }
 
         private JiraSettings createJiraSettings()


### PR DESCRIPTION
Fixes https://github.com/solidify/jira-azuredevops-migrator/issues/723
Smoke tests: https://dev.azure.com/solidify/Internal/_build/results?buildId=12956&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9