### PR TITLE
Use the EpicLink field from the config when migrating epic links

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -246,7 +246,7 @@ namespace JiraExport
             }
 
             // map epic link
-            LinkMapperUtils.AddRemoveSingleLink(r, links, _jiraProvider.GetSettings().EpicLinkField, "Epic", _config);
+            LinkMapperUtils.AddRemoveSingleLink(r, links, _config.EpicLinkField, "Epic", _config);
 
             // map parent
             LinkMapperUtils.AddRemoveSingleLink(r, links, "parent", "Parent", _config);


### PR DESCRIPTION
Fixes https://github.com/solidify/jira-azuredevops-migrator/issues/862
Smoke tests: https://dev.azure.com/solidify/Internal/_build/results?buildId=14012&view=results