### PR TITLE
Add support for OAuth2 token using -t flag

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraCommandLine.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraCommandLine.cs
@@ -37,6 +37,7 @@ namespace JiraExport
 
             CommandOption userOption = commandLineApplication.Option("-u <username>", "Username for authentication", CommandOptionType.SingleValue);
             CommandOption passwordOption = commandLineApplication.Option("-p <password>", "Password for authentication", CommandOptionType.SingleValue);
+            CommandOption tokenOption = commandLineApplication.Option("-t <token>", "Bearer token for OAuth2 authentication", CommandOptionType.SingleValue);
             CommandOption urlOption = commandLineApplication.Option("--url <accounturl>", "Url for the account", CommandOptionType.SingleValue);
             CommandOption configOption = commandLineApplication.Option("--config <configurationfilename>", "Export the work items based on this configuration file", CommandOptionType.SingleValue);
             CommandOption forceOption = commandLineApplication.Option("--force", "Forces execution from start (instead of continuing from previous run)", CommandOptionType.NoValue);
@@ -49,7 +50,7 @@ namespace JiraExport
 
                 if (configOption.HasValue())
                 {
-                    succeeded = ExecuteMigration(userOption, passwordOption, urlOption, configOption, forceFresh, continueOnCriticalOption);
+                    succeeded = ExecuteMigration(userOption, passwordOption, tokenOption, urlOption, configOption, forceFresh, continueOnCriticalOption);
                 }
                 else
                 {
@@ -60,7 +61,7 @@ namespace JiraExport
             });
         }
 
-        private bool ExecuteMigration(CommandOption user, CommandOption password, CommandOption url, CommandOption configFile, bool forceFresh, CommandOption continueOnCritical)
+        private bool ExecuteMigration(CommandOption user, CommandOption password, CommandOption token, CommandOption url, CommandOption configFile, bool forceFresh, CommandOption continueOnCritical)
         {
             var itemsCount = 0;
             var exportedItemsCount = 0;
@@ -82,7 +83,7 @@ namespace JiraExport
 
                 var downloadOptions = (DownloadOptions)config.DownloadOptions;
 
-                var jiraSettings = new JiraSettings(user.Value(), password.Value(), url.Value(), config.SourceProject)
+                var jiraSettings = new JiraSettings(user.Value(), password.Value(), token.Value(), url.Value(), config.SourceProject)
                 {
                     BatchSize = config.BatchSize,
                     UserMappingFile = config.UserMappingFile != null ? Path.Combine(migrationWorkspace, config.UserMappingFile) : string.Empty,

--- a/src/WorkItemMigrator/JiraExport/JiraServiceWrapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraServiceWrapper.cs
@@ -3,6 +3,7 @@ using Atlassian.Jira.Remote;
 using JiraExport;
 using Migration.Common.Log;
 using RestSharp;
+using RestSharp.Authenticators;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -27,6 +28,10 @@ namespace JiraExport
 
                 _jira = Jira.CreateRestClient(jiraSettings.Url, jiraSettings.UserID, jiraSettings.Pass);
                 _jira.RestClient.RestSharpClient.AddDefaultHeader("X-Atlassian-Token", "no-check");
+
+                if (!string.IsNullOrWhiteSpace(jiraSettings.Token))
+                    _jira.RestClient.RestSharpClient.Authenticator = new OAuth2AuthorizationRequestHeaderAuthenticator(jiraSettings.Token, "Bearer");
+
                 if (jiraSettings.UsingJiraCloud)
                     _jira.RestClient.Settings.EnableUserPrivacyMode = true;
             }

--- a/src/WorkItemMigrator/JiraExport/JiraSettings.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraSettings.cs
@@ -1,5 +1,6 @@
 ﻿
 using Migration.Common.Config;
+using Newtonsoft.Json.Linq;
 
 namespace JiraExport
 {
@@ -7,6 +8,7 @@ namespace JiraExport
     {
         public string UserID { get; private set; }
         public string Pass { get; private set; }
+        public string Token { get; private set; }
         public string Url { get; private set; }
         public string Project { get; set; }
         public string EpicLinkField { get; set; }
@@ -19,10 +21,11 @@ namespace JiraExport
         public bool IncludeCommits { get; set; }
         public RepositoryMap RepositoryMap { get; set; }
 
-        public JiraSettings(string userID, string pass, string url, string project)
+        public JiraSettings(string userID, string pass, string token, string url, string project)
         {
             UserID = userID;
             Pass = pass;
+            Token = token;
             Url = url;
             Project = project;
         }

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraItemTests.cs
@@ -668,7 +668,7 @@ namespace Migration.Jira_Export.Tests
 
         private JiraSettings createJiraSettings()
         {
-            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            JiraSettings settings = new JiraSettings("userID", "pass", "token", "url", "project");
             settings.EpicLinkField = "EpicLinkField";
             settings.SprintField = "SprintField";
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraMapperTests.cs
@@ -232,7 +232,7 @@ namespace Migration.Jira_Export.Tests
 
         private JiraSettings createJiraSettings()
         {
-            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            JiraSettings settings = new JiraSettings("userID", "pass", "token", "url", "project");
             settings.EpicLinkField = "Epic Link";
             settings.SprintField = "SprintField";
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraRevisionTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/JiraRevisionTests.cs
@@ -73,7 +73,7 @@ namespace Migration.Jira_Export.Tests
 
         private JiraSettings createJiraSettings()
         {
-            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            JiraSettings settings = new JiraSettings("userID", "pass", "token", "url", "project");
             settings.EpicLinkField = "EpicLinkField";
             settings.SprintField = "SprintField";
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
@@ -32,7 +32,7 @@ namespace Migration.Jira_Export.Tests.RevisionUtils
             };
 
             provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
-            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            JiraSettings settings = new JiraSettings("userID", "pass", "token", "url", "project");
             settings.SprintField = "SprintField";
             provider.GetSettings().ReturnsForAnyArgs(settings);
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/LinkMapperUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/LinkMapperUtilsTests.cs
@@ -32,7 +32,7 @@ namespace Migration.Jira_Export.Tests.RevisionUtils
             };
 
             provider.DownloadIssue(default).ReturnsForAnyArgs(remoteIssue);
-            JiraSettings settings = new JiraSettings("userID", "pass", "url", "project");
+            JiraSettings settings = new JiraSettings("userID", "pass", "token", "url", "project");
             settings.SprintField = "SprintField";
             provider.GetSettings().ReturnsForAnyArgs(settings);
 


### PR DESCRIPTION
This change adds a new flag to the command line -t which accepts a token parameter.  When the flag is present, an Authorisation header is added for the token as a Bearer token using RestSharp authentication functionality.

> `new OAuth2AuthorizationRequestHeaderAuthenticator(jiraSettings.Token, "Bearer");`

There are no tests for this code because no tests exist for any of the other parameters, and I'm unsure how you'd want me to meaningfully mock the behaviour of an OAuth2 system.  If this is unacceptable, please advise on what sort of tests you'd like me to add and I'll do so.  However, the existing tests have been updated to reflect the method signature changes and all of them pass.