### PR TITLE
Provide ability to handle multiple custom fields with the same name.

### DIFF
--- a/src/WorkItemMigrator/JiraExport/IJiraProvider.cs
+++ b/src/WorkItemMigrator/JiraExport/IJiraProvider.cs
@@ -29,7 +29,11 @@ namespace JiraExport
 
         bool GetCustomFieldSerializer(string customType, out ICustomFieldValueSerializer serializer);
 
+        /// <inheritdoc cref="JiraProvider.GetCustomId"/>
         string GetCustomId(string propertyName);
+        /// <inheritdoc cref="JiraProvider.GetCustomIdList"/>
+        List<string> GetCustomIdList(string propertyName);
+        
         Task<List<RevisionAction<JiraAttachment>>> DownloadAttachments(JiraRevision rev);
 
         IEnumerable<JObject> GetCommitRepositories(string issueId);

--- a/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
+++ b/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
@@ -183,6 +183,27 @@ namespace JiraExport
             return iterationPath;
         }
 
+        /// <summary>
+        /// Find the first custom field with the right name that has a value.
+        /// </summary>
+        /// <param name="fields"><see cref="JiraRevision.Fields">JiraRevision.Fields</see> dictionary.</param>
+        /// <param name="customFieldIds">The IDs of the Custom Fields to search - more than one custom field can have the same name.</param>
+        /// <param name="fieldValueObject">The value of the first field in the list that has a value.</param>
+        /// <returns>True if one of the identified custom fields contains a value.</returns>
+        private static bool TryGetFirstValue(this Dictionary<string,object> fields, List<string> customFieldIds, out object fieldValueObject)
+        {
+            foreach(var name in customFieldIds)
+            {
+                if (fields.TryGetValue(name.ToLower(), out fieldValueObject))
+                {
+                    return true;
+                }
+            }
+
+            fieldValueObject = null;
+            return false;
+        }
+
         private static readonly Dictionary<string, decimal> CalculatedLexoRanks = new Dictionary<string, decimal>();
         private static readonly Dictionary<decimal, string> CalculatedRanks = new Dictionary<decimal, string>();
 


### PR DESCRIPTION
In larger Jira instances it is surprisingly common to find two custom fields with the same name.  Currently the mapping code naively chooses one of the fields up front and uses it for all items.  

The proposal instead collects a list of matching fields during the building of the mappers and then for each item the fields are checked sequentially, and the first field that actually contains a value is used.  This will not fix items that where more than one of the same-named fields contain a value.

This is a **draft request** in order to get an opinion of what the team thinks of it.  It has **not been tested thoroughly enough for pulling** yet.

Note: this commit only adds the capability, further changes are required to switch usages of TryGetValue() in the field mappers of FieldMapperUtils for FieldMapperUtils.TryGetFirstValue().