### PR TITLE
Provide ability to handle multiple custom fields with the same name.

### DIFF
--- a/src/WorkItemMigrator/JiraExport/IJiraProvider.cs
+++ b/src/WorkItemMigrator/JiraExport/IJiraProvider.cs
@@ -29,7 +29,11 @@ namespace JiraExport
 
         bool GetCustomFieldSerializer(string customType, out ICustomFieldValueSerializer serializer);
 
+        /// <inheritdoc cref="JiraProvider.GetCustomId"/>
         string GetCustomId(string propertyName);
+        /// <inheritdoc cref="JiraProvider.GetCustomIdList"/>
+        List<string> GetCustomIdList(string propertyName);
+        
         Task<List<RevisionAction<JiraAttachment>>> DownloadAttachments(JiraRevision rev);
 
         IEnumerable<JObject> GetCommitRepositories(string issueId);

--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -379,16 +379,19 @@ namespace JiraExport
             return types;
         }
 
-        private Func<JiraRevision, (bool, object)> IfChanged<T>(string sourceField, bool isCustomField, Func<T, object> mapperFunc = null)
+        internal Func<JiraRevision, (bool, object)> IfChanged<T>(string sourceField, bool isCustomField, Func<T, object> mapperFunc = null)
         {
+            List<string> sourceFields = null;
             if (isCustomField)
             {
-                sourceField = _jiraProvider.GetCustomId(sourceField) ?? sourceField;
+                sourceFields = _jiraProvider.GetCustomIdList(sourceField);
             }
+
+            sourceFields = sourceFields ?? new List<string> { sourceField };
 
             return (r) =>
             {
-                if (r.Fields.TryGetValue(sourceField.ToLower(), out object value))
+                if (r.Fields.TryGetFirstValue(sourceFields, out object value))
                 {
                     if (mapperFunc != null)
                     {

--- a/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
+++ b/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
@@ -12,7 +12,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+
+[assembly: InternalsVisibleTo("Migration.Jira-Export.Tests")]
+
 
 namespace JiraExport
 {

--- a/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
+++ b/src/WorkItemMigrator/JiraExport/RevisionUtils/FieldMapperUtils.cs
@@ -183,6 +183,27 @@ namespace JiraExport
             return iterationPath;
         }
 
+        /// <summary>
+        /// Find the first custom field with the right name that has a value.
+        /// </summary>
+        /// <param name="fields"><see cref="JiraRevision.Fields">JiraRevision.Fields</see> dictionary.</param>
+        /// <param name="customFieldIds">The IDs of the Custom Fields to search - more than one custom field can have the same name.</param>
+        /// <param name="fieldValueObject">The value of the first field in the list that has a value.  Null if no values are found.</param>
+        /// <returns>True if one of the identified custom fields contains a value.</returns>
+        internal static bool TryGetFirstValue(this Dictionary<string,object> fields, List<string> customFieldIds, out object fieldValueObject)
+        {
+            foreach(var name in customFieldIds)
+            {
+                if (fields.TryGetValue(name, out fieldValueObject) && fieldValueObject != null)
+                {
+                    return true;
+                }
+            }
+
+            fieldValueObject = null;
+            return false;
+        }
+
         private static readonly Dictionary<string, decimal> CalculatedLexoRanks = new Dictionary<string, decimal>();
         private static readonly Dictionary<decimal, string> CalculatedRanks = new Dictionary<decimal, string>();
 

--- a/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
+++ b/src/WorkItemMigrator/tests/Migration.Jira-Export.Tests/RevisionUtils/FieldMapperUtilsTests.cs
@@ -489,5 +489,132 @@ namespace Migration.Jira_Export.Tests.RevisionUtils
         {
             Assert.That(FieldMapperUtils.MapLexoRank("0|hzyxfj:hzyxfj"), Is.EqualTo(1088341183.1088341M));
         }
+
+
+        /**
+         ****************      TryGetFirstValue Tests     ****************
+         */
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnTrue_WhenMatchingFieldExists()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>
+        {
+            { "field1", "value1" },
+            { "field2", "value2" },
+            { "field3", "value3" }
+        };
+            var customFieldIds = new List<string> { "field2", "field3" };
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsTrue(result);
+            Assert.AreEqual("value2", fieldValueObject);
+        }
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnFalse_WhenNoMatchingFieldExists()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>
+        {
+            { "field1", "value1" },
+            { "field2", "value2" },
+            { "field3", "value3" }
+        };
+            var customFieldIds = new List<string> { "field4", "field5" };
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.IsNull(fieldValueObject);
+        }
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnFalse_WhenFieldsDictionaryIsEmpty()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>();
+            var customFieldIds = new List<string> { "field1", "field2" };
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.IsNull(fieldValueObject);
+        }
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnFalse_WhenCustomFieldIdsListIsEmpty()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>
+        {
+            { "field1", "value1" },
+            { "field2", "value2" },
+            { "field3", "value3" }
+        };
+            var customFieldIds = new List<string>();
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.IsNull(fieldValueObject);
+        }
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnTrue_WhenMultipleMatchingFieldsExistButOnlyOneHasNonNullValue()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>
+            {
+                { "field1", null },
+                { "field2", "value2" },
+                { "field3", null }
+            };
+            var customFieldIds = new List<string> { "field1", "field3", "field2" };
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsTrue(result);
+            Assert.AreEqual("value2", fieldValueObject);
+        }
+
+
+        [Test]
+        public void TryGetFirstValue_ShouldReturnFalse_WhenMultipleMatchingFieldsExistButOnlyAllAreNullValue()
+        {
+            // Arrange
+            var fields = new Dictionary<string, object>
+            {
+                { "field1", null },
+                { "field2", null },
+                { "field3", null }
+            };
+            var customFieldIds = new List<string> { "field1", "field3", "field2" };
+            object fieldValueObject;
+
+            // Act
+            var result = fields.TryGetFirstValue(customFieldIds, out fieldValueObject);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.IsNull(fieldValueObject);
+        }
     }
 }


### PR DESCRIPTION
In larger Jira instances it is surprisingly common to find two custom fields with the same name. Currently the mapping code naively chooses one of the fields up front and uses it for all items.

The proposal instead collects a list of matching fields during the building of the mappers and then for each item the fields are checked sequentially, and the first field that actually contains a value is used. This will not fix items where more than one of the same-named fields contain a value.

This is a draft request in order to get an opinion of what the team thinks of it. It has not been tested thoroughly enough for pulling yet.

Note: the previous pull request with branch SameNameFields, this PR is for branch SameNameFields2.
This PR **includes code to actually make use of this change** unlike the previous one.  Indeed this is done inside the IfChanged<T> method, and so **is applied for nearly every field**.  It also contains a number of bug fixes, and more extensive unit tests.