### PR TITLE
Omit the default field extraction mapping for Sprint. Let the configuration handle sprint mapping instead.

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraItem.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraItem.cs
@@ -467,7 +467,6 @@ namespace JiraExport
                         { "assignee", extractAccountIdOrUsername },
                         { "creator", extractAccountIdOrUsername },
                         { "reporter", extractAccountIdOrUsername},
-                        { jira.GetSettings().SprintField, t => string.Join(", ", ParseCustomField(jira.GetSettings().SprintField, t, jira)) },
                         { "status", extractName },
                         { "parent", t => t.ExValue<string>("$.key") },
                         { "issuetype", extractName },


### PR DESCRIPTION
Potentially fixes https://github.com/solidify/jira-azuredevops-migrator/issues/1048