### PR TITLE
Add option to defer ExecutionItems until later.

### DIFF
--- a/src/WorkItemMigrator/Migration.Common.Log/AttachmentNotFoundException.cs
+++ b/src/WorkItemMigrator/Migration.Common.Log/AttachmentNotFoundException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Migration.Common.Log
+{
+    [Serializable]
+    public class AttachmentNotFoundException : Exception
+    {
+        protected AttachmentNotFoundException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
+        {
+
+        }
+
+        public AttachmentNotFoundException(string reason)
+        {
+            Reason = reason;
+        }
+
+        public string Reason { get; private set; }
+    }
+}

--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -126,6 +126,10 @@ namespace WorkItemImport
                     {
                         _witClientUtils.CorrectDescription(wi, _context.GetItem(rev.ParentOriginId), rev, _context.Journal.IsAttachmentMigrated);
                     }
+                    catch (AttachmentNotFoundException)
+                    {
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         Logger.Log(ex, $"Failed to correct description for '{wi.Id}', rev '{rev}'.");
@@ -151,6 +155,10 @@ namespace WorkItemImport
                                     field.Target,
                                     _context.Journal.IsAttachmentMigrated
                                 );
+                            }
+                            catch (AttachmentNotFoundException)
+                            {
+                                throw;
                             }
                             catch (Exception ex)
                             {

--- a/src/WorkItemMigrator/WorkItemImport/Agent.cs
+++ b/src/WorkItemMigrator/WorkItemImport/Agent.cs
@@ -190,6 +190,10 @@ namespace WorkItemImport
             {
                 throw;
             }
+            catch (AttachmentNotFoundException)
+            {
+                throw;
+            }
             catch (FileNotFoundException ex)
             {
                 Logger.Log(LogLevel.Error, ex.Message);

--- a/src/WorkItemMigrator/WorkItemImport/ExecutionPlan.cs
+++ b/src/WorkItemMigrator/WorkItemImport/ExecutionPlan.cs
@@ -12,6 +12,7 @@ namespace WorkItemImport
             public int WiId { get; set; } = -1;
             public WiRevision Revision { get; set; }
             public string WiType { get; internal set; }
+            public bool isDeferred { get; set; }
 
             public override string ToString()
             {
@@ -43,6 +44,18 @@ namespace WorkItemImport
             if (ReferenceQueue.Count > 0)
             {
                 nextItem = TransformToExecutionItem(ReferenceQueue.Dequeue());
+                return true;
+            }
+            else
+                return false;
+        }
+
+        public bool TryPeek(out ExecutionItem nextItem)
+        {
+            nextItem = null;
+            if (ReferenceQueue.Count > 0)
+            {
+                nextItem = TransformToExecutionItem(ReferenceQueue.Peek());
                 return true;
             }
             else

--- a/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
+++ b/src/WorkItemMigrator/WorkItemImport/WitClient/WitClientUtils.cs
@@ -771,7 +771,10 @@ namespace WorkItemImport
                         isUpdated = true;
                     }
                     else
-                        Logger.Log(LogLevel.Warning, $"Attachment '{att}' referenced in text but is missing from work item {wiItem.OriginId}/{wi.Id}.");
+                    {
+                        Logger.Log(LogLevel.Warning, $"Attachment '{att}' referenced in text but is missing from work item {wiItem.OriginId}/{wi.Id}. This revision will be deferred until later.");
+                        throw new AttachmentNotFoundException("Attachment not found on work item");
+                    }
                 }
             }
             if (isUpdated)


### PR DESCRIPTION
This fixes a bug where revisions are not imported if they contain rendered fields which reference attachments which for various reasons are uploaded in a later revision.