### PR TITLE
Truncate System.Description field

### DIFF
--- a/src/WorkItemMigrator/JiraExport/JiraMapper.cs
+++ b/src/WorkItemMigrator/JiraExport/JiraMapper.cs
@@ -470,7 +470,8 @@ namespace JiraExport
             string valueStr = value.ToString();
             var fieldLimits = new Dictionary<string, int>()
             {
-                { WiFieldReference.Title, 255 }
+                { WiFieldReference.Title, 255 },
+                { WiFieldReference.Description, 1048576 }
             };
             if (fieldLimits.ContainsKey(field))
             {


### PR DESCRIPTION
Truncate the System.Description field if it is longer than the maximum allowed length of 1048576 characters.